### PR TITLE
[FEAT] 알라딘 API를 사용한 베스트셀러 조회

### DIFF
--- a/src/controllers/books.controller.ts
+++ b/src/controllers/books.controller.ts
@@ -2,27 +2,33 @@ import { z } from "zod";
 import { defaultEndpointsFactory } from "express-zod-api";
 import { bookSearchResponseSchema } from "../schemas/aladin.schema.js";
 import { bookDetailResponseSchema } from "../schemas/books.schema.js";
-import { searchBooks, getBookDetail } from "../services/books.service.js";
-import { authMiddleware } from "../middlewares/auth.middleware.js"; 
+import { searchBooks, getBookDetail, viewBestsellers } from "../services/books.service.js";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+
+const authEndpointsFactory = defaultEndpointsFactory.addMiddleware(authMiddleware);
 
 // GET /api/v1/books/search?q=
 // 알라딘 API 기반 도서 검색
-const authEndpointsFactory = defaultEndpointsFactory.addMiddleware(authMiddleware);
-
 export const handleSearchBooks = authEndpointsFactory.build({
     method: "get",
     input: z.object({
         q: z.string().min(1),
-        start: z.string().optional().default("1").transform((val) => parseInt(val, 10)),
-        maxResults: z.string().optional().default("30").transform((val) => parseInt(val, 10)),
+        start: z
+            .string()
+            .optional()
+            .default("1")
+            .transform((val) => parseInt(val, 10)),
+        maxResults: z
+            .string()
+            .optional()
+            .default("30")
+            .transform((val) => parseInt(val, 10)),
     }),
     output: bookSearchResponseSchema,
     handler: async ({ input }) => {
         return await searchBooks(input.q, input.start, input.maxResults);
     },
 });
-
-
 
 // GET /api/v1/books/:bookId
 // 책 상세 정보 조회
@@ -34,5 +40,27 @@ export const handleGetBookDetail = authEndpointsFactory.build({
     output: bookDetailResponseSchema,
     handler: async ({ input }) => {
         return await getBookDetail(input.bookId);
+    },
+});
+
+// GET /api/v1/books/bestsellers
+// 베스트셀러 조회
+export const handleViewBestsellers = authEndpointsFactory.build({
+    method: "get",
+    input: z.object({
+        start: z
+            .string()
+            .optional()
+            .default("1")
+            .transform((val) => parseInt(val, 10)),
+        maxResults: z
+            .string()
+            .optional()
+            .default("30")
+            .transform((val) => parseInt(val, 10)),
+    }),
+    output: bookSearchResponseSchema,
+    handler: async ({ input }) => {
+        return await viewBestsellers(input.start, input.maxResults);
     },
 });

--- a/src/repositories/aladin.repository.ts
+++ b/src/repositories/aladin.repository.ts
@@ -1,5 +1,5 @@
-import { aladinConfig } from '../config/aladin.config.js';
-import {AladinApiResponse, AladinApiItem, AladinItemLookupResponse} from "../schemas/aladin.schema.js";
+import { aladinConfig } from "../config/aladin.config.js";
+import { AladinApiResponse, AladinApiItem, AladinItemLookupResponse } from "../schemas/aladin.schema.js";
 import HttpErrors from "http-errors";
 
 const apiKey = aladinConfig.ALADIN_API_KEY;
@@ -55,5 +55,29 @@ export const getBookDetailFromAladin = async (itemId: number): Promise<AladinApi
     }
 
     return data.item[0];
+};
 
+// 알라딘 검색 베스트셀러 조회 (ItemList)
+export const viewBestsellersFromAladin = async (
+    start: number = 1,
+    maxResults: number = 30
+): Promise<AladinApiResponse> => {
+    const url = new URL(`${baseUrl}/ItemList.aspx`);
+
+    url.searchParams.append("ttbkey", apiKey);
+    url.searchParams.append("QueryType", "Bestseller");
+    url.searchParams.append("MaxResults", maxResults.toString());
+    url.searchParams.append("Start", start.toString());
+    url.searchParams.append("SearchTarget", "Book");
+    url.searchParams.append("Output", "JS");
+    url.searchParams.append("Version", "20131101");
+    const response = await fetch(url.toString());
+
+    if (!response.ok) {
+        throw HttpErrors(response.status, "알라딘 API 호출 실패");
+    }
+
+    const data = await response.json();
+    console.log(data);
+    return data as AladinApiResponse;
 };

--- a/src/routes/routes.index.ts
+++ b/src/routes/routes.index.ts
@@ -1,6 +1,5 @@
 import { Routing } from "express-zod-api";
-import { handleSearchBooks, handleGetBookDetail } from "../controllers/books.controller.js";
-
+import { handleSearchBooks, handleGetBookDetail, handleViewBestsellers } from "../controllers/books.controller.js";
 import {
     handleLogin,
     handleRefreshToken,
@@ -9,13 +8,13 @@ import {
     handleWithdrawUser,
 } from "../controllers/auth.controller.js";
 
-
 export const routing: Routing = {
     api: {
         v1: {
             books: {
                 search: handleSearchBooks,
-                ":bookId": handleGetBookDetail,  
+                bestsellers: handleViewBestsellers,
+                ":bookId": handleGetBookDetail,
             },
             auth: {
                 login: handleLogin,

--- a/src/schemas/aladin.schema.ts
+++ b/src/schemas/aladin.schema.ts
@@ -4,29 +4,27 @@ import { z } from "zod";
 export const aladinBookItemSchema = z.object({
     itemId: z.number(), // 알라딘 내부 도서 ID
     title: z.string(), // 제목
-    author: z.string(),  // 저자
+    author: z.string(), // 저자
     publisher: z.string(), // 출판사
     pubDate: z.string(), // 출간일
     description: z.string(), // 책 소개
-    isbn13: z.string(),  // ISBN13
+    isbn13: z.string(), // ISBN13
     cover: z.string(), // 표지 이미지 URL
-    categoryNames: z.array(z.string()).optional(),// 카테고리 경로
+    categoryNames: z.array(z.string()).optional(), // 카테고리 경로
 });
 
 // 검색 API 전체 응답 스키마
 export const bookSearchResponseSchema = z.object({
-    totalResults: z.number(),      // 전체 검색 결과 수
-    startIndex: z.number(),        // 현재 페이지 시작 위치
-    hasMore: z.boolean(),          // 다음 결과가 더 있는지 여부
-    itemsPerPage: z.number(),      // 한 번에 받은 아이템 수
-    items: z.array(aladinBookItemSchema),  // 책 리스트
+    totalResults: z.number(), // 전체 검색 결과 수
+    startIndex: z.number(), // 현재 페이지 시작 위치
+    hasMore: z.boolean(), // 다음 결과가 더 있는지 여부
+    itemsPerPage: z.number(), // 한 번에 받은 아이템 수
+    items: z.array(aladinBookItemSchema), // 책 리스트
 });
 
 // TypeScript 추론 타입
 export type AladinBookItem = z.infer<typeof aladinBookItemSchema>;
 export type BookSearchResponse = z.infer<typeof bookSearchResponseSchema>;
-
-
 
 /* 알라딘의 ItemSearch / ItemLookUp API에서 내려오는 
 "책 한 권"의 원시(JSON) 데이터 구조를 표현하는 타입. */
@@ -41,12 +39,11 @@ export interface AladinApiItem {
     cover: string;
     categoryName?: string;
     subInfo?: {
-        itemPage?: number;  
+        itemPage?: number;
     };
 }
 
-
-//알라딘 검색 API(ItemSearch) 원본 응답 타입
+//알라딘 검색 API(ItemSearch), 베스트셀러 조회 API(ItemList) 원본 응답 타입
 export interface AladinApiResponse {
     item: AladinApiItem[];
     totalResults: number;


### PR DESCRIPTION
## 작업 내용
- 알라딘 API를 사용하여 온보딩 시 활용할 베스트셀러 조회 API 개발
- 기본 30개씩 결과 반환
- 책 검색 API와 서비스 로직이 거의 동일하여 중복되는 부분을 함수로 만들어서 사용

## 테스트
<img width="1367" height="811" alt="스크린샷 2025-12-03 150825" src="https://github.com/user-attachments/assets/9c3604dc-14d7-4fcb-a5b2-30eb37338d4c" />
- 공통 부분을 함수로 리팩토링한 후 책 검색 API도 테스트한 결과 정상 작동하는 것을 볼 수 있음
<img width="1382" height="809" alt="스크린샷 2025-12-03 150906" src="https://github.com/user-attachments/assets/38b36ed5-03b7-4eaf-95e9-d2f1c6d1f1b5" />

Closes #28 
