### PR TITLE
[FEAT] 북마크 제거 기능 구현

### DIFF
--- a/src/controllers/books.controller.ts
+++ b/src/controllers/books.controller.ts
@@ -4,7 +4,7 @@ import { bookSearchResponseSchema } from "../schemas/aladin.schema.js";
 import { bookDetailResponseSchema, bookmarkResponseSchema } from "../schemas/books.schema.js";
 import { searchBooks, getBookDetail, viewBestsellers } from "../services/books.service.js";
 import { authMiddleware } from "../middlewares/auth.middleware.js"; 
-import { addBookmark  } from "../services/bookmarks.service.js";
+import { addBookmark, removeBookmark } from "../services/bookmarks.service.js";
 
 const authEndpointsFactory = defaultEndpointsFactory.addMiddleware(authMiddleware);
 
@@ -71,3 +71,20 @@ export const handleAddBookmark = authEndpointsFactory.build({
         return await addBookmark(userId, input.bookId);
     },
 }); 
+
+// DELETE /api/v1/books/:bookId/bookmark
+// 북마크 삭제
+export const handleDeleteBookmark = authEndpointsFactory.build({
+    method: "delete",
+    input: z.object({
+        bookId: z.string().transform((val) => parseInt(val, 10)),
+    }),
+    output: z.object({
+        message: z.string(),
+    }),
+    handler: async ({ input, options }) => {
+        const userId = options.user.user_id;
+        await removeBookmark(userId, input.bookId);
+        return { message: "Bookmark 삭제되었습니다." };
+    },
+});

--- a/src/repositories/bookmarks.repository.ts
+++ b/src/repositories/bookmarks.repository.ts
@@ -1,7 +1,8 @@
-// src/repositories/bookmarks.repository.ts
 import { pool } from "../config/db.config.js";
 import { ResultSetHeader } from "mysql2/promise";
 
+
+// 북마크 추가
 export const insertBookmark = async (userId: number, bookId: number) => {
     try {
         const [result] = await pool.query<ResultSetHeader>(
@@ -17,3 +18,14 @@ export const insertBookmark = async (userId: number, bookId: number) => {
     }
 };
 
+// 북마크 삭제
+export const deleteBookmark = async (
+    userId: number,
+    bookId: number,
+) => {
+    const [result] = await pool.query<ResultSetHeader>(
+        `DELETE FROM bookmark WHERE user_id = ? AND book_id = ?`,
+        [userId, bookId],
+    );
+    return result;
+};

--- a/src/routes/routes.index.ts
+++ b/src/routes/routes.index.ts
@@ -1,6 +1,11 @@
 import { Routing } from "express-zod-api";
-import { handleSearchBooks, handleGetBookDetail, handleViewBestsellers, handleAddBookmark } from "../controllers/books.controller.js";
-
+import { 
+    handleSearchBooks, 
+    handleGetBookDetail, 
+    handleViewBestsellers, 
+    handleAddBookmark, 
+    handleDeleteBookmark 
+} from "../controllers/books.controller.js";
 
 import {
     handleLogin,
@@ -19,6 +24,7 @@ export const routing: Routing = {
                 bestsellers: handleViewBestsellers,
                 ":bookId": handleGetBookDetail,  
                 ":bookId/bookmark": handleAddBookmark,
+                "delete /:bookId/bookmark": handleDeleteBookmark,
             },
             auth: {
                 login: handleLogin,

--- a/src/services/bookmarks.service.ts
+++ b/src/services/bookmarks.service.ts
@@ -1,12 +1,12 @@
-// src/services/bookmarks.service.ts
-import createHttpError from "http-errors";
+import HttpError from "http-errors";
 import { BookmarkResponse } from "../schemas/books.schema.js";
 import { findBookByItemId } from "../repositories/books.repository.js";
 import {
     insertBookmark,
-
+    deleteBookmark,
 } from "../repositories/bookmarks.repository.js";
 
+// 북마크 추가 
 export const addBookmark = async (
     userId: number,
     aladinItemId: number,
@@ -14,7 +14,7 @@ export const addBookmark = async (
 
     const bookRow = await findBookByItemId(aladinItemId.toString());
     if (!bookRow) {
-        throw createHttpError(404, "책 정보를 찾을 수 없습니다.");
+        throw HttpError(404, "책 정보를 찾을 수 없습니다.");
     }
 
     try {
@@ -26,9 +26,22 @@ export const addBookmark = async (
         };
     } catch (err: any) {
         if (err.message === "DUPLICATE_BOOKMARK") {
-            throw createHttpError(409, "이미 북마크한 책입니다.");
+            throw HttpError(409, "이미 북마크한 책입니다.");
         }
         throw err;
     }
 };
 
+// 북마크 삭제
+export const removeBookmark = async (userId: number, aladinItemId: number) => {
+    const bookRow = await findBookByItemId(aladinItemId.toString());
+    if (!bookRow) {
+        throw HttpError(404, "책 정보를 찾을 수 없습니다.");
+    }
+
+    const result = await deleteBookmark(userId, bookRow.book_id);
+
+    if (result.affectedRows === 0) {
+        throw HttpError(404, "북마크가 존재하지 않습니다.");
+    }
+};


### PR DESCRIPTION
## 구현 내용
- 북마크 제거 API 구현
- 사용자가 북마크 해제를 요청하면 user_id와 book_id를 기준으로 bookmark 테이블에서 해당되는 북마크 내용을 삭제

## 테스트
---
### 북마크 정보가 있는 상태에서 호출
<img width="465" height="217" alt="image" src="https://github.com/user-attachments/assets/230f9383-1f48-49c9-b861-2130ff9edcdb" />
<img width="1611" height="1108" alt="image" src="https://github.com/user-attachments/assets/92759df5-9a8d-484e-a7b5-0e3cd98b1bef" />


DB에서 확인 
<img width="475" height="254" alt="image" src="https://github.com/user-attachments/assets/aeebead7-198e-4803-aeb6-23d2c908311b" />
북마크가 제거된 것을 볼 수 있다.


### 북마크가 없는 상황에서 호출
<img width="1573" height="1228" alt="image" src="https://github.com/user-attachments/assets/3ec72e4e-9a61-4cc2-a12e-76a7542366df" />
북마크가 존재하지 않는다는 에러가 뜨는 것을 확인할 수 있다.