### PR TITLE
[FIX] RDS migration 환경 구축

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -46,7 +46,7 @@ jobs:
                       --env-file /opt/app/.env \
                       --name checkmate-migrate \
                       ${{ secrets.DOCKER_USERNAME }}/checkmate-server \
-                      npm run migrate
+                      npm run migrate:prod
                       
                     sudo docker stop checkmate || true
                     sudo docker rm checkmate || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ COPY --from=builder /app/node_modules ./node_modules
 # 2. 컴파일된 코드 및 필요한 파일 복사
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package*.json ./
+# migration 폴더 복사
+COPY --from=builder /app/migrations ./migrations
 
 # 3. 포트 노출
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "start": "node dist/index.js",
         "docs": "tsx scripts/generate-openapi.ts",
         "migrate": "tsx src/config/migrator.config.ts up",
+        "migrate:prod": "node dist/config/migrator.config.js up",
         "migrate:down": "tsx src/config/migrator.config.ts down",
         "migrate:create": "tsx src/config/migrator.config.ts create --name"
     },


### PR DESCRIPTION
## 작업 내용
- ENOTFOUND 에러는 EC2 .env 파일의 환경변수 따옴표 제거로 해결
- DB를 RDS에 마이그레이션하기 위해 Dockerfile, package.json, deploy-yml을 변경

1. Dockerfile
- migrations 폴더가 src 폴더와 같은 레벨에 위치해서(=src 폴더에 포함되지 않아서) 빌드에서 제외됨. 따라서 마이그레이션 명령어가 EC2에서 작동하지 않음
- migrations 폴더를 빌드에 포함시킴

2. package.json
- 개발용 migration 명령어와 프로덕션용 migration 명령어를 따로 정의. 프로덕션용은 빌드된 후이기 때문에 .js 파일을 사용

3. deploy-yml
- 배포 시 프로덕션용 migration 명령어를 사용하게끔 함

## 전달 사항
- 배포되어야만 DB에 잘 적용되는지 볼 수 있어서 부득이하게 테스트 없이 올립니다...!

Closes #50