### PR TITLE
[FEAT] 내가 좋아요한 인용구 조회 API 구현

### DIFF
--- a/src/controllers/mypage.controller.ts
+++ b/src/controllers/mypage.controller.ts
@@ -1,13 +1,12 @@
 import { z } from "zod";
 import { defaultEndpointsFactory } from "express-zod-api";
-import { getMyPageInfo, getUserBookmarks } from "../services/mypage.service.js";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { mypageOutputSchema } from "../schemas/mypage.schema.js";
 import { userBookmarksResponseSchema } from "../schemas/books.schema.js";
 import { myQuotesResponseSchema } from "../schemas/quotes.schema.js";
 import { getMyQuotesService } from "../services/mypage.service.js";
 import { myDiscussionsResponseSchema } from "../schemas/discussions.schema.js";
-import { getMyDiscussionsService } from "../services/mypage.service.js";
+import { getMyPageInfo, getUserBookmarks, getLikedQuotesService, getMyDiscussionsService } from "../services/mypage.service.js";
 
 // 인증이 필요한 엔드포인트용 팩토리
 const authEndpointsFactory = defaultEndpointsFactory.addMiddleware(authMiddleware);
@@ -62,5 +61,19 @@ export const handleGetMyDiscussions = authEndpointsFactory.build({
     handler: async ({ input, options }) => {
         const userId = options.user.user_id;
         return await getMyDiscussionsService(userId, input.page, input.limit);
+    },
+});
+
+// 내가 좋아요한 인용구 조회
+export const handleGetLikedQuotes = authEndpointsFactory.build({
+    method: "get",
+    input: z.object({
+        page: z.coerce.number().int().positive().default(1),
+        limit: z.coerce.number().int().positive().max(50).default(10),
+    }),
+    output: myQuotesResponseSchema,
+    handler: async ({ input, options }) => {
+        const userId = options.user.user_id;
+        return await getLikedQuotesService(userId, input.page, input.limit);
     },
 });

--- a/src/repositories/discussions.repository.ts
+++ b/src/repositories/discussions.repository.ts
@@ -13,7 +13,6 @@ export const getDiscussionsByUserId = async (
             d.discussion_id,
             d.title,
             d.content,
-            d.view_count,
             d.like_count,
             d.created_at,
             b.book_id,

--- a/src/routes/routes.index.ts
+++ b/src/routes/routes.index.ts
@@ -1,5 +1,5 @@
 import { Routing } from "express-zod-api";
-import { handleGetMyPage, handleGetMyBookshelf, handleGetMyQuotes, handleGetMyDiscussions, } from "../controllers/mypage.controller.js";
+import { handleGetMyPage, handleGetMyBookshelf, handleGetMyQuotes, handleGetMyDiscussions, handleGetLikedQuotes } from "../controllers/mypage.controller.js";
 
 import { 
     handleSearchBooks, 
@@ -62,6 +62,7 @@ export const routing: Routing = {
                 "bookmarks/books": handleGetMyBookshelf,
                 "my-quotes": handleGetMyQuotes,
                 "my-discussions": handleGetMyDiscussions,
+                "like/quotes": handleGetLikedQuotes,
             },
 
             quotes: {

--- a/src/schemas/discussions.schema.ts
+++ b/src/schemas/discussions.schema.ts
@@ -6,7 +6,6 @@ export const myDiscussionSchema = z.object({
     discussion_id: z.number().int(),
     title: z.string(),
     content: z.string().nullable(),
-    view_count: z.number().int(),
     like_count: z.number().int(),
     comment_count: z.number().int(),
     created_at: z.string(),

--- a/src/services/mypage.service.ts
+++ b/src/services/mypage.service.ts
@@ -1,11 +1,16 @@
 import HttpError from "http-errors";
 import { MypageOutput } from "../schemas/mypage.schema.js";
-import { MyQuoteRow } from "../schemas/quotes.schema.js";
-import { findGenresByBookId } from "../repositories/books.repository.js";
 import { UserBookmarksResponse, BookmarkItem } from "../schemas/books.schema.js";
-import { countBookmarksByUserId, getBookmarksWithPagination } from "../repositories/bookmarks.repository.js";
-import { getQuotesByUserId, countQuotesByUserId } from "../repositories/quotes.repository.js";
+import { MyQuoteRow } from "../schemas/quotes.schema.js";
 import { MyDiscussionRow, MyDiscussionsResponse } from "../schemas/discussions.schema.js";
+import { findGenresByBookId } from "../repositories/books.repository.js";
+import { countBookmarksByUserId, getBookmarksWithPagination } from "../repositories/bookmarks.repository.js";
+import {
+    getQuotesByUserId,
+    countQuotesByUserId,
+    getLikedQuotesByUserId,
+    countLikedQuotesByUserId,
+} from "../repositories/quotes.repository.js";
 import {
     getDiscussionsByUserId,
     countDiscussionsByUserId,
@@ -31,6 +36,29 @@ const processPagination = (page: number, limit: number, totalCount: number) => {
         totalPages,
         offset,
         hasNext,
+    };
+};
+
+// 인용구 데이터 변환 헬퍼 함수
+const transformQuoteData = (row: MyQuoteRow) => {
+    const date = new Date(row.created_at);
+    const yy = String(date.getFullYear()).slice(-2);
+    const mm = String(date.getMonth() + 1).padStart(2, "0");
+    const dd = String(date.getDate()).padStart(2, "0");
+
+    return {
+        quote_id: row.quote_id,
+        content: row.content,
+        like_count: row.like_count,
+        created_at: `${yy}.${mm}.${dd}`,
+        book: {
+            book_id: row.book_id,
+            title: row.book_title,
+            genres: row.genre_names ? row.genre_names.split(",") : [],
+        },
+        user: {
+            nickname: row.nickname,
+        },
     };
 };
 
@@ -114,28 +142,7 @@ export const getMyQuotesService = async (
 
     try {
         const quotes = await getQuotesByUserId(userId, safeLimit, offset);
-
-        const data = quotes.map((row: MyQuoteRow) => {
-            const date = new Date(row.created_at);
-            const yy = String(date.getFullYear()).slice(-2);
-            const mm = String(date.getMonth() + 1).padStart(2, "0");
-            const dd = String(date.getDate()).padStart(2, "0");
-
-            return {
-                quote_id: row.quote_id,
-                content: row.content,
-                like_count: row.like_count,
-                created_at: `${yy}.${mm}.${dd}`,
-                book: {
-                    book_id: row.book_id,
-                    title: row.book_title,
-                    genres: row.genre_names ? row.genre_names.split(",") : [],
-                },
-                user: {
-                    nickname: row.nickname,
-                },
-            };
-        });
+        const data = quotes.map(transformQuoteData);
 
         return {
             page: safePage,
@@ -198,5 +205,32 @@ export const getMyDiscussionsService = async (
     } catch (err) {
         console.error(err);
         throw HttpError(500, "내 토론 조회에 실패했습니다.");
+    }
+};
+
+// 내가 좋아요한 인용구 조회 (페이지네이션)
+export const getLikedQuotesService = async (
+    userId: number,
+    page: number,
+    limit: number
+) => {
+    const totalCount = await countLikedQuotesByUserId(userId);
+    const { safePage, safeLimit, totalPages, offset, hasNext } = processPagination(page, limit, totalCount);
+
+    try {
+        const quotes = await getLikedQuotesByUserId(userId, safeLimit, offset);
+        const data = quotes.map(transformQuoteData);
+
+        return {
+            page: safePage,
+            limit: safeLimit,
+            total_count: totalCount,
+            total_pages: totalPages,
+            has_next: hasNext,
+            quotes: data,
+        };
+    } catch (err) {
+        console.error(err);
+        throw HttpError(500, "좋아요한 인용구 조회에 실패했습니다.");
     }
 };


### PR DESCRIPTION
## 작업 내용
- 사용자가 좋아요한 인용구 목록을 조회하는 API 구현
- quote_like 테이블을에 들어 좋아요한 인용구를 최신순으로 조회
- GET /api/v1/users/like/quotes?page=1&limit=10

## 테스트
- 사전 준비
- 유저 4와 유저 5가 적은 인용구 목록을 2개씩 준비 
- 유저 4의 인용구1과 유저 5의 인용구2에 유저1이 좋아요를 했다고 가정
<img width="1333" height="369" alt="image" src="https://github.com/user-attachments/assets/3a489eea-c7c3-409a-9c59-59167547df66" />

<img width="1455" height="1830" alt="image" src="https://github.com/user-attachments/assets/2b733498-d83c-46c3-8382-512ef0951698" />
유저 1로 GET /api/v1/users/like/quotes 호출한 결과 좋아요한 글만 보내주는 것을 확인할 수 있다. 