### PR TITLE
[FEAT] 좋아요한 토론 목록 조회 API 구현

### DIFF
--- a/src/controllers/mypage.controller.ts
+++ b/src/controllers/mypage.controller.ts
@@ -6,7 +6,8 @@ import { userBookmarksResponseSchema } from "../schemas/books.schema.js";
 import { myQuotesResponseSchema } from "../schemas/quotes.schema.js";
 import { getMyQuotesService } from "../services/mypage.service.js";
 import { myDiscussionsResponseSchema } from "../schemas/discussions.schema.js";
-import { getMyPageInfo, getUserBookmarks, getLikedQuotesService, getMyDiscussionsService } from "../services/mypage.service.js";
+
+import { getMyPageInfo, getUserBookmarks, getLikedQuotesService, getMyDiscussionsService, getLikedDiscussionsService, } from "../services/mypage.service.js";
 
 // 인증이 필요한 엔드포인트용 팩토리
 const authEndpointsFactory = defaultEndpointsFactory.addMiddleware(authMiddleware);
@@ -75,5 +76,19 @@ export const handleGetLikedQuotes = authEndpointsFactory.build({
     handler: async ({ input, options }) => {
         const userId = options.user.user_id;
         return await getLikedQuotesService(userId, input.page, input.limit);
+    },
+});
+
+// 내가 좋아요한 토론 조회
+export const handleGetLikedDiscussions = authEndpointsFactory.build({
+    method: "get",
+    input: z.object({
+        page: z.coerce.number().int().positive().default(1),
+        limit: z.coerce.number().int().positive().max(50).default(10),
+    }),
+    output: myDiscussionsResponseSchema,
+    handler: async ({ input, options }) => {
+        const userId = options.user.user_id;
+        return await getLikedDiscussionsService(userId, input.page, input.limit);
     },
 });

--- a/src/repositories/discussions.repository.ts
+++ b/src/repositories/discussions.repository.ts
@@ -1,29 +1,35 @@
 import { pool } from "../config/db.config.js";
 import { MyDiscussionRow } from "../schemas/discussions.schema.js";
 
-// 사용자별 토론 리스트 조회 (책 정보, 댓글 수 포함)
-export const getDiscussionsByUserId = async (
+// 토론 리스트 조회 헬퍼 함수 (내가 작성한 / 좋아요한 공통)
+const getDiscussionsWithDetails = async (
     userId: number,
     limit: number,
-    offset: number
+    offset: number,
+    type: "written" | "liked"
 ): Promise<MyDiscussionRow[]> => {
+    const isLiked = type === "liked";
+
     const [rows] = await pool.query<MyDiscussionRow[]>(
         `
         SELECT 
             d.discussion_id,
             d.title,
             d.content,
+            d.view_count,
             d.like_count,
             d.created_at,
             b.book_id,
             b.title AS book_title,
             u.nickname,
             (SELECT COUNT(*) FROM discussion_comment dc WHERE dc.discussion_id = d.discussion_id) AS comment_count
-        FROM discussion d
+            ${isLiked ? ", MAX(dl.like_id) AS liked_at" : ""}
+        FROM ${isLiked ? "discussion_like dl INNER JOIN discussion d ON dl.discussion_id = d.discussion_id" : "discussion d"}
         INNER JOIN book b ON d.book_id = b.book_id
         INNER JOIN user u ON d.user_id = u.user_id
-        WHERE d.user_id = ?
-        ORDER BY d.created_at DESC
+        WHERE ${isLiked ? "dl" : "d"}.user_id = ?
+        GROUP BY d.discussion_id
+        ORDER BY ${isLiked ? "liked_at" : "d.created_at"} DESC
         LIMIT ? OFFSET ?
         `,
         [userId, limit, offset]
@@ -32,10 +38,38 @@ export const getDiscussionsByUserId = async (
     return rows;
 };
 
+// 사용자별 토론 리스트 조회 (책 정보, 댓글 수 포함)
+export const getDiscussionsByUserId = async (
+    userId: number,
+    limit: number,
+    offset: number
+): Promise<MyDiscussionRow[]> => {
+    return getDiscussionsWithDetails(userId, limit, offset, "written");
+};
+
+// 사용자가 좋아요한 토론 리스트 조회 (책 정보, 댓글 수 포함)
+export const getLikedDiscussionsByUserId = async (
+    userId: number,
+    limit: number,
+    offset: number
+): Promise<MyDiscussionRow[]> => {
+    return getDiscussionsWithDetails(userId, limit, offset, "liked");
+};
+
 // 사용자 토론 총 개수 조회
 export const countDiscussionsByUserId = async (userId: number): Promise<number> => {
     const [rows] = await pool.query<any[]>(
         `SELECT COUNT(*) AS total FROM discussion WHERE user_id = ?`,
+        [userId]
+    );
+
+    return rows[0].total;
+};
+
+// 사용자가 좋아요한 토론 총 개수 조회
+export const countLikedDiscussionsByUserId = async (userId: number): Promise<number> => {
+    const [rows] = await pool.query<any[]>(
+        `SELECT COUNT(*) AS total FROM discussion_like WHERE user_id = ?`,
         [userId]
     );
 

--- a/src/routes/routes.index.ts
+++ b/src/routes/routes.index.ts
@@ -1,5 +1,12 @@
 import { Routing } from "express-zod-api";
-import { handleGetMyPage, handleGetMyBookshelf, handleGetMyQuotes, handleGetMyDiscussions, handleGetLikedQuotes } from "../controllers/mypage.controller.js";
+import {
+    handleGetMyPage,
+    handleGetMyBookshelf,
+    handleGetMyQuotes,
+    handleGetMyDiscussions,
+    handleGetLikedQuotes,
+    handleGetLikedDiscussions,
+} from "../controllers/mypage.controller.js";
 
 import { 
     handleSearchBooks, 
@@ -63,6 +70,7 @@ export const routing: Routing = {
                 "my-quotes": handleGetMyQuotes,
                 "my-discussions": handleGetMyDiscussions,
                 "like/quotes": handleGetLikedQuotes,
+                "like/discussions": handleGetLikedDiscussions,
             },
 
             quotes: {

--- a/src/services/mypage.service.ts
+++ b/src/services/mypage.service.ts
@@ -14,6 +14,8 @@ import {
 import {
     getDiscussionsByUserId,
     countDiscussionsByUserId,
+    getLikedDiscussionsByUserId,
+    countLikedDiscussionsByUserId,
 } from "../repositories/discussions.repository.js";
 import {
     getUserById,
@@ -55,6 +57,31 @@ const transformQuoteData = (row: MyQuoteRow) => {
             book_id: row.book_id,
             title: row.book_title,
             genres: row.genre_names ? row.genre_names.split(",") : [],
+        },
+        user: {
+            nickname: row.nickname,
+        },
+    };
+};
+
+// 토론 데이터 변환 헬퍼 함수
+const transformDiscussionData = (row: MyDiscussionRow) => {
+    const date = new Date(row.created_at);
+    const yy = String(date.getFullYear()).slice(-2);
+    const mm = String(date.getMonth() + 1).padStart(2, "0");
+    const dd = String(date.getDate()).padStart(2, "0");
+
+    return {
+        discussion_id: row.discussion_id,
+        title: row.title,
+        content: row.content,
+        view_count: row.view_count,
+        like_count: row.like_count,
+        comment_count: row.comment_count,
+        created_at: `${yy}.${mm}.${dd}`,
+        book: {
+            book_id: row.book_id,
+            title: row.book_title,
         },
         user: {
             nickname: row.nickname,
@@ -169,30 +196,7 @@ export const getMyDiscussionsService = async (
 
     try {
         const discussions = await getDiscussionsByUserId(userId, safeLimit, offset);
-
-        const data = discussions.map((row: MyDiscussionRow) => {
-            const date = new Date(row.created_at);
-            const yy = String(date.getFullYear()).slice(-2);
-            const mm = String(date.getMonth() + 1).padStart(2, "0");
-            const dd = String(date.getDate()).padStart(2, "0");
-
-            return {
-                discussion_id: row.discussion_id,
-                title: row.title,
-                content: row.content,
-                view_count: row.view_count,
-                like_count: row.like_count,
-                comment_count: row.comment_count,
-                created_at: `${yy}.${mm}.${dd}`,
-                book: {
-                    book_id: row.book_id,
-                    title: row.book_title,
-                },
-                user: {
-                    nickname: row.nickname,
-                },
-            };
-        });
+        const data = discussions.map(transformDiscussionData);
 
         return {
             page: safePage,
@@ -232,5 +236,32 @@ export const getLikedQuotesService = async (
     } catch (err) {
         console.error(err);
         throw HttpError(500, "좋아요한 인용구 조회에 실패했습니다.");
+    }
+};
+
+// 내가 좋아요한 토론 조회 (페이지네이션)
+export const getLikedDiscussionsService = async (
+    userId: number,
+    page: number,
+    limit: number
+): Promise<MyDiscussionsResponse> => {
+    const totalCount = await countLikedDiscussionsByUserId(userId);
+    const { safePage, safeLimit, totalPages, offset, hasNext } = processPagination(page, limit, totalCount);
+
+    try {
+        const discussions = await getLikedDiscussionsByUserId(userId, safeLimit, offset);
+        const data = discussions.map(transformDiscussionData);
+
+        return {
+            page: safePage,
+            limit: safeLimit,
+            total_count: totalCount,
+            total_pages: totalPages,
+            has_next: hasNext,
+            discussions: data,
+        };
+    } catch (err) {
+        console.error(err);
+        throw HttpError(500, "좋아요한 토론 조회에 실패했습니다.");
     }
 };


### PR DESCRIPTION
## 작업내용
- 사용자가 좋아요한 토론 목록을 조회하는 API 구현
- discussion_like 테이블을 확인하여 좋아요한 토론을 최신순으로 조회
- 내가 작성한 토론 조회 API와 동일한 형식을 보내기 때문에 공통함수 transformDiscussionData를 만들어 사용


## 테스트
유저4와 유저5에게 자유토론, vs토론 더미 데이터를 넣어서 확인
유저4와 유저5의 자유토론에만 유저1이 좋아요를 했다는 상황을 가정
<img width="2627" height="287" alt="image" src="https://github.com/user-attachments/assets/ac277185-cb81-4262-a26d-d651fe2d5655" />

<img width="1806" height="1741" alt="image" src="https://github.com/user-attachments/assets/120d66f6-717a-472b-af42-395022bcbe49" />
API 호출 결과 좋아요한 자유토론들만 보내주는 것을 확인 할 수 있다. 