### PR TITLE
[FIX] CORS 에러 해결

### DIFF
--- a/src/config/api.config.ts
+++ b/src/config/api.config.ts
@@ -40,7 +40,14 @@ export const apiConfig = createConfig({
             })
         );
     },
-    cors: true,
+    cors: ({ defaultHeaders }) => {
+        return {
+            ...defaultHeaders,
+            // 'Authorization' 헤더가 포함된 요청을 허용하도록 명시
+            "Access-Control-Allow-Headers": "Authorization, Content-Type",
+            "Access-Control-Max-Age": "5000",
+        };
+    },
     logger: {
         level: process.env.NODE_ENV === "production" ? "warn" : "debug",
         color: true,


### PR DESCRIPTION
## 작업 내용
- 인증을 위해 토큰을 header에 담아 보낼 때 Authorization이라는 HTTP 헤더를 사용
- Authorization 헤더는 허용된 헤더 목록(Access-Control-Allow-Headers)에 없기 때문에 생기는 에러
- 기존에는 cors: true로만 되어 있던 코드를 Authorization 코드를 명시적으로 허용하는 것을 수정
- 스웨거에서는 작동하는 이유: Swagger UI가 호스팅되는 서버와 API 서버가 동일한 출처(Same Origin)로 간주되어 CORS 제약이 적용되지 않은 것으로 추정

## 전달 내용
- 스웨거에서는 테스트가 안 돼서 배포한 후 프론트에서 테스트해야 할 것 같습니다.