### PR TITLE
[FIX]  마이페이지 조회 API DB 변경 사항 반영

### DIFF
--- a/src/repositories/mypage.repository.ts
+++ b/src/repositories/mypage.repository.ts
@@ -33,9 +33,9 @@ export const getExpByUserId = async (userId: number): Promise<ExpRow | null> => 
 // 사용자 선호 장르 조회 
 export const getPreferredGenresByUserId = async (userId: number): Promise<string[]> => {
     const [rows] = await pool.query<GenreRow[]>(
-        `SELECT DISTINCT g.genre_name
+        `SELECT DISTINCT og.genre_name
         FROM user_genre ug
-        INNER JOIN genre g ON ug.genre_id = g.genre_id
+        INNER JOIN onboarding_genre og ON ug.onboarding_genre_id = og.onboarding_genre_id
         WHERE ug.user_id = ?`,
         [userId]
     );


### PR DESCRIPTION
## 작업내용
- 유저 장르 DB 변경 사항 반영
- genre_id 에서 -> onboarding_genre_id 변경


## 테스트 
<img width="1715" height="956" alt="image" src="https://github.com/user-attachments/assets/e9e0df46-0ba5-4a32-b628-870836275563" />

<img width="1626" height="1280" alt="image" src="https://github.com/user-attachments/assets/13c78f84-360d-4230-b483-5831d038ccb5" />

온보딩 선호장르 선택 때 선택한 장르가 제대로 조회되는 것을 확인할 수 있다.
 