### PR TITLE
[REFACTOR] 회원가입 시 닉네임 포함

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -5,6 +5,7 @@ import {
     loginOutputSchema,
     refreshInputSchema,
     refreshOutputSchema,
+    signupInputSchema,
     signupOutputSchema,
 } from "../schemas/users.schema.js";
 import { refreshAccessToken, userLogin, userSignup, userLogout, userWithdrawal } from "../services/users.service.js";
@@ -36,7 +37,7 @@ export const handleRefreshToken = defaultEndpointsFactory.build({
 // 회원가입
 export const handleSignup = defaultEndpointsFactory.build({
     method: "post",
-    input: loginInputSchema,
+    input: signupInputSchema,
     output: signupOutputSchema,
     handler: async ({ input }) => {
         return await userSignup(input);

--- a/src/repositories/users.repository.ts
+++ b/src/repositories/users.repository.ts
@@ -1,6 +1,7 @@
 import { pool } from "../config/db.config.js";
 import { User, RefreshToken, OnboardingGenre } from "../schemas/users.schema.js";
 import { ResultSetHeader } from "mysql2/promise";
+
 // 이메일로 사용자 조회
 export const getUserByEmail = async (userEmail: string): Promise<User | null> => {
     const [rows] = await pool.query<User[]>(`SELECT * FROM user WHERE email = ?;`, [userEmail]);
@@ -32,12 +33,12 @@ export const deleteRefreshToken = async (token: string): Promise<number> => {
 };
 
 // 사용자 생성
-export const createUser = async (userEmail: string, password: string): Promise<User | null> => {
+export const createUser = async (userEmail: string, password: string, nickname: string): Promise<User | null> => {
     // INSERT 쿼리 실행
-    const [result] = await pool.query<ResultSetHeader>("INSERT INTO user (email, password) VALUES (?, ?);", [
-        userEmail,
-        password,
-    ]);
+    const [result] = await pool.query<ResultSetHeader>(
+        "INSERT INTO user (email, password, nickname) VALUES (?, ?, ?);",
+        [userEmail, password, nickname]
+    );
 
     // 삽입 실패 또는 affectedRows가 0인 경우 처리
     if (result.affectedRows === 0) {

--- a/src/schemas/users.schema.ts
+++ b/src/schemas/users.schema.ts
@@ -37,6 +37,13 @@ export const refreshOutputSchema = z.object({
     accessToken: z.string(),
 });
 
+// Signup Input 스키마
+export const signupInputSchema = userSchema.pick({
+    email: true,
+    password: true,
+    nickname: true,
+});
+
 // Signup Output 스키마
 export const signupOutputSchema = z.object({
     accessToken: z.string(),
@@ -44,6 +51,7 @@ export const signupOutputSchema = z.object({
     user: userSchema.pick({
         user_id: true,
         email: true,
+        nickname: true,
     }),
 });
 
@@ -70,6 +78,7 @@ export type LoginInput = z.infer<typeof loginInputSchema>;
 export type LoginOutput = z.infer<typeof loginOutputSchema>;
 export type RefreshTokenInput = z.infer<typeof refreshInputSchema>;
 export type RefreshTokenOutput = z.infer<typeof refreshOutputSchema>;
+export type SignupInput = z.infer<typeof signupInputSchema>;
 export type SignupOutput = z.infer<typeof signupOutputSchema>;
 export type ModifyUserInput = z.infer<typeof modifyUserInputSchema>;
 export type OnboardingGenreOutput = z.infer<typeof onboardingGenreOutputSchema>;

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -7,6 +7,7 @@ import {
     OnboardingGenreOutput,
     RefreshTokenInput,
     RefreshTokenOutput,
+    SignupInput,
     SignupOutput,
 } from "../schemas/users.schema.js";
 import {
@@ -115,7 +116,7 @@ export const userLogout = async (input: RefreshTokenInput): Promise<string> => {
     }
 };
 
-export const userSignup = async (input: LoginInput): Promise<SignupOutput> => {
+export const userSignup = async (input: SignupInput): Promise<SignupOutput> => {
     // 사용자 중복 검사
     const isDuplicated = await getUserByEmail(input.email);
     if (isDuplicated) {
@@ -124,7 +125,7 @@ export const userSignup = async (input: LoginInput): Promise<SignupOutput> => {
 
     const password = await bcrypt.hash(input.password, 10);
 
-    const user = await createUser(input.email, password);
+    const user = await createUser(input.email, password, input.nickname);
 
     if (!user) {
         throw HttpError(500, "사용자 생성에 실패했습니다.");
@@ -148,6 +149,7 @@ export const userSignup = async (input: LoginInput): Promise<SignupOutput> => {
         user: {
             user_id: user.user_id,
             email: user.email,
+            nickname: user.nickname,
         },
     };
 };


### PR DESCRIPTION
## 작업 내용
- 회원가입 시 body에 닉네임을 받도록 수정

## 테스트
<img width="1359" height="801" alt="스크린샷 2025-12-09 160637" src="https://github.com/user-attachments/assets/df3c5936-8921-440a-9ef4-e83f7793eda3" />
- DB에도 잘 들어가는 것을 볼 수 있다.
<img width="1477" height="422" alt="스크린샷 2025-12-09 160802" src="https://github.com/user-attachments/assets/f8932233-a32b-4427-9e25-5b7a6e46f91a" />

## 전달 내용
- 사실상 이제 닉네임을 수정하는 API인 `PATCH /api/v1/users/me`가 필요 없어졌습니다...! 하지만 추후 사용자 정보 수정 기능을 개발할 수도 있으니(피프 기능에는 포함이 안 되어 있지만, 확장성을 위해) 따로 삭제는 하지 않았습니다.