### PR TITLE
[FIX] 특정 책 토론 목록 조회 응답에 좋아요/댓글 수 추가 

### DIFF
--- a/src/repositories/discussions_M.repository.ts
+++ b/src/repositories/discussions_M.repository.ts
@@ -1,3 +1,4 @@
+import { NumberLiteralType } from "typescript";
 import { pool } from "../config/db.config.js";
 import { RowDataPacket, ResultSetHeader } from "mysql2/promise";
 
@@ -14,6 +15,8 @@ export interface DiscussionRow extends RowDataPacket {
   created_at: Date;
   updated_at: Date;
   nickname: string; 
+  comment_count: number;
+  like_count: number; 
 }
 
 //책 존재여부 확인
@@ -41,6 +44,7 @@ export interface CreateDiscussionPayload {
   discussion_type: "FREE" | "VS";
   option1: string | null;
   option2: string | null;
+
 }
 
 export const createDiscussion = async (
@@ -89,10 +93,14 @@ export const getDiscussionsByBook = async (
       d.option1,
       d.option2,
       d.created_at,
-      u.nickname
+      d.like_count,
+      u.nickname,
+      COUNT(dc.comment_id) AS comment_count
     FROM discussion d
     INNER JOIN user u ON d.user_id = u.user_id
+    LEFT JOIN discussion_comment dc ON dc.discussion_id = d.discussion_id
     WHERE d.book_id = ?
+    GROUP BY d.discussion_id
     ORDER BY d.created_at DESC
     `,
     [bookId]

--- a/src/schemas/discussions_M.schema.ts
+++ b/src/schemas/discussions_M.schema.ts
@@ -9,7 +9,7 @@ export const createDiscussionInputSchema = z.object({
   content: z.string().min(1),
   discussion_type: discussionTypeEnum,
   option1: z.string().optional(),
-  option2: z.string().optional(),
+  option2: z.string().optional(),   
 })
 .refine(
   (data) => {
@@ -57,6 +57,8 @@ export const discussionListItemSchema = z.object({
   option2: z.string().nullable(),
   created_at: z.date(),
   nickname: z.string(),
+  like_count: z.number(),
+  comment_count: z.number(),
 });
 
 export const getDiscussionsByBookResponseSchema = z.object({


### PR DESCRIPTION
**추가사항**
GET /api/v1/books/:bookId/discussions 응답에 `like_count`, `comment_count` 필드 추가

**테스트**
좋아요와 댓글수 정상반환
<img width="2667" height="1494" alt="스크린샷 2025-12-10 004411" src="https://github.com/user-attachments/assets/d695d5bf-6820-47c8-aa63-2919715744bb" />

close #83 