### PR TITLE
[FIX] 도서별 인용구 조회 응답 구조 추가

### DIFF
--- a/src/controllers/quotes.controller.ts
+++ b/src/controllers/quotes.controller.ts
@@ -10,7 +10,7 @@ import {
   likeQuoteService,
   unlikeQuoteService,
 } from "../services/quotes.service.js";
-import { quoteSchema } from "../schemas/quotes.schema.js";
+import { quoteWithBookSchema, quoteSchema } from "../schemas/quotes.schema.js";
 
 const authEndpointsFactory = defaultEndpointsFactory.addMiddleware(authMiddleware);
 
@@ -111,7 +111,7 @@ export const handleGetQuotesByBook = authEndpointsFactory.build({
     bookId: z.coerce.number().int().positive(),
   }),
   output: z.object({
-    data: z.array(quoteSchema),
+    data: z.array(quoteWithBookSchema),
   }),
 
   handler: async ({ input }) => {

--- a/src/repositories/quotes.repository.ts
+++ b/src/repositories/quotes.repository.ts
@@ -45,12 +45,10 @@ export const getQuoteById = async (
 };
 
 // 책별 인용구 리스트 조회
-export const getQuotesByBookId = async (
-  bookId: number
-): Promise<QuoteRow[]> => {
-  const [rows] = await pool.query<QuoteRow[]>(
+export const getQuotesByBookId = async (bookId: number): Promise<any[]> => {
+  const [rows] = await pool.query<any[]>(
     `
-      SELECT 
+      SELECT
         q.quote_id,
         q.user_id,
         u.nickname,
@@ -58,15 +56,23 @@ export const getQuotesByBookId = async (
         q.content,
         q.like_count,
         q.created_at,
-        q.updated_at
+        q.updated_at,
+
+        b.title,
+        b.author,
+        b.publisher,
+        b.published_date,
+        b.description,
+        b.thumbnail_url,
+        b.page_count
       FROM quote q
       INNER JOIN user u ON q.user_id = u.user_id
+      INNER JOIN book b ON q.book_id = b.book_id
       WHERE q.book_id = ?
       ORDER BY q.created_at DESC
     `,
     [bookId]
   );
-
   return rows;
 };
 

--- a/src/routes/routes.index.ts
+++ b/src/routes/routes.index.ts
@@ -69,7 +69,7 @@ export const routing: Routing = {
 
       discussions: {
         ":discussionId/messages": handleCreateDiscussionMessage,
-         "get :discussionId": handleGetDiscussionDetail,
+        "get :discussionId": handleGetDiscussionDetail,
       },
       
       books: {

--- a/src/schemas/quotes.schema.ts
+++ b/src/schemas/quotes.schema.ts
@@ -18,6 +18,21 @@ export const quoteSchema = z.object({
   updated_at: z.iso.datetime().nullable(),
 });
 
+export const bookSchema = z.object({
+  title: z.string(),
+  author: z.string(),
+  publisher: z.string().nullable(),
+  published_date: z.string().nullable(),
+  description: z.string().nullable(),
+  thumbnail_url: z.string().nullable(),
+  page_count: z.number().nullable(),
+});
+
+export const quoteWithBookSchema = quoteSchema.extend({
+  book: bookSchema,
+});
+
+
 // 내 인용구 목록용 스키마 (책 정보 포함)
 export const myQuoteSchema = z.object({
   quote_id: z.number().int(),

--- a/src/services/quotes.service.ts
+++ b/src/services/quotes.service.ts
@@ -31,23 +31,31 @@ return {
   };
 };
 
-// READ by book
+// 도서별 인용구 조회
 export const getQuotesByBookService = async (bookId: number) => {
-  try {
-    const rows = await getQuotesByBookId(bookId);
+  const rows = await getQuotesByBookId(bookId);
 
-    return rows.map((row: any) => ({
-      ...row,
-      created_at: row.created_at.toISOString(),
-      updated_at: row.updated_at ? row.updated_at.toISOString() : null,
-    }));
-  } catch (err) {
-    console.error(err);
-    throw HttpError(500, "도서별 인용구 조회 실패");
-  }
+  return rows.map((row) => ({
+    quote_id: row.quote_id,
+    user_id: row.user_id,
+    nickname: row.nickname,
+    book_id: row.book_id,
+    content: row.content,
+    like_count: row.like_count,
+    created_at: row.created_at.toISOString(),
+    updated_at: row.updated_at ? row.updated_at.toISOString() : null,
+
+    book: {
+      title: row.title,
+      author: row.author,
+      publisher: row.publisher,
+      published_date: row.published_date,
+      description: row.description,
+      thumbnail_url: row.thumbnail_url,
+      page_count: row.page_count,
+    },
+  }));
 };
-
-
 // UPDATE
 export const updateQuoteService = async (quoteId: number, content: string, userId: number) => {
   const quote = await getQuoteById(quoteId);


### PR DESCRIPTION
**작업내용**
-특정 도서의 인용구 목록 조회 API에서 책 정보(title, author, thumbnail 등)가 누락문제 수정
-책 상세 화면에서 인용구 목록을 표시할 때  책 정보를 추가로 제공
-api/v1/books/{bookId}/quotes

**테스트**
해당책에 관한 정보 반환
<img width="1279" height="1370" alt="스크린샷 2025-12-10 173237" src="https://github.com/user-attachments/assets/26795521-45a8-4e39-b074-86953568cc3c" />