### PR TITLE
[FEAT] 토론 좋아요 등록 기능 구현 

### DIFF
--- a/src/controllers/discussions_M.controller.ts
+++ b/src/controllers/discussions_M.controller.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { defaultEndpointsFactory } from "express-zod-api";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 
@@ -18,6 +19,14 @@ import {
     getDiscussionDetailService,
     getDiscussionMessagesService,
 } from "../services/discussions_M.service.js";
+
+import {
+    discussionLikeInputSchema,
+    discussionLikeResponseSchema,
+} from "../schemas/discussions_M.schema.js";
+
+import { likeDiscussionService } from "../services/discussions_M.service.js";
+
 
 // 인증된 API 팩토리
 const authEndpointsFactory = defaultEndpointsFactory.addMiddleware(authMiddleware);
@@ -77,5 +86,20 @@ export const handleGetDiscussionMessages = authEndpointsFactory.build({
     handler: async ({ input }) => {
     const messages = await getDiscussionMessagesService(input.discussionId);
     return { messages };
+    },
+});
+
+// 토론 좋아요 등록
+export const handleLikeDiscussion = authEndpointsFactory.build({
+    method: "post",
+    input: discussionLikeInputSchema,
+    output: discussionLikeResponseSchema,
+
+    handler: async ({ input, options }) => {
+    const userId = options.user.user_id;
+    const discussionId = input.discussionId;
+
+    const result = await likeDiscussionService(userId, discussionId);
+    return result;
     },
 });

--- a/src/repositories/discussions_M.repository.ts
+++ b/src/repositories/discussions_M.repository.ts
@@ -187,3 +187,48 @@ export const getDiscussionMessages = async (
 
   return rows as DiscussionMessageRow[];
 };
+
+// 이미 좋아요를 눌렀는지 확인
+export const findDiscussionLike = async (
+  userId: number,
+  discussionId: number
+) => {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `
+    SELECT like_id
+    FROM discussion_like
+    WHERE user_id = ? AND discussion_id = ?
+    `,
+    [userId, discussionId]
+  );
+
+  return rows.length ? rows[0] : null;
+};
+
+// 좋아요 추가
+export const addDiscussionLike = async (
+  userId: number,
+  discussionId: number
+) => {
+  const [result] = await pool.query<ResultSetHeader>(
+    `
+    INSERT INTO discussion_like (user_id, discussion_id)
+    VALUES (?, ?)
+    `,
+    [userId, discussionId]
+  );
+
+  return result.insertId;
+};
+
+// 좋아요 갯수 1 증가
+export const increaseDiscussionLikeCount = async (discussionId: number) => {
+  await pool.query(
+    `
+    UPDATE discussion
+    SET like_count = like_count + 1
+    WHERE discussion_id = ?
+    `,
+    [discussionId]
+  );
+};

--- a/src/routes/routes.index.ts
+++ b/src/routes/routes.index.ts
@@ -56,6 +56,7 @@ import {
   handleGetDiscussionsByBook,
   handleGetDiscussionDetail,
   handleGetDiscussionMessages,
+  handleLikeDiscussion,
 } from "../controllers/discussions_M.controller.js";
 
 export const routing: Routing = {
@@ -71,6 +72,7 @@ export const routing: Routing = {
       discussions: {
         "get :discussionId": handleGetDiscussionDetail,
         "get :discussionId/messages": handleGetDiscussionMessages,
+        "post :discussionId/like": handleLikeDiscussion, 
       },
       books: {
         search: handleSearchBooks,

--- a/src/schemas/discussions_M.schema.ts
+++ b/src/schemas/discussions_M.schema.ts
@@ -103,12 +103,22 @@ export const discussionMessageSchema = z.object({
   updated_at: z.date().nullable(),
 });
 
-// Input 스키마
+//토론 메시지 Input 스키마
 export const getDiscussionMessagesInputSchema = z.object({
   discussionId: z.coerce.number().int().positive(),
 });
 
-// Response 스키마
+//토론 메시지 Response 스키마
 export const getDiscussionMessagesResponseSchema = z.object({
   messages: z.array(discussionMessageSchema),
+});
+
+//좋아요Input 스키마
+export const discussionLikeInputSchema = z.object({
+  discussionId: z.coerce.number().int().positive(),
+});
+
+//좋아요 Response 스키마
+export const discussionLikeResponseSchema = z.object({
+  message: z.string(),
 });

--- a/src/services/discussions_M.service.ts
+++ b/src/services/discussions_M.service.ts
@@ -1,9 +1,15 @@
 import HttpError from "http-errors";
 import { getBookById } from "../repositories/books.repository.js";
-import { createDiscussion } from "../repositories/discussions_M.repository.js";
-import { getDiscussionsByBook } from "../repositories/discussions_M.repository.js";
+import {
+    createDiscussion,
+    getDiscussionsByBook,
+    getDiscussionDetail,
+    getDiscussionMessages,
+    findDiscussionLike,
+    addDiscussionLike,
+    increaseDiscussionLikeCount,
+} from "../repositories/discussions_M.repository.js";
 
-import { getDiscussionMessages } from "../repositories/discussions_M.repository.js";
 
 export const createDiscussionService = async (payload: {
     user_id: number;
@@ -63,8 +69,6 @@ export const getDiscussionsByBookService = async (bookId: number) => {
 };
 
 //토론상세조회
-import { getDiscussionDetail } from "../repositories/discussions_M.repository.js";
-
 export const getDiscussionDetailService = async (discussionId: number) => {
     const discussion = await getDiscussionDetail(discussionId);
 
@@ -85,4 +89,28 @@ export const getDiscussionMessagesService = async (discussionId: number) => {
 
     const messages = await getDiscussionMessages(discussionId);
     return messages;
+};
+
+// 토론 좋아요 등록
+export const likeDiscussionService = async (
+    userId: number,
+    discussionId: number
+) => {
+  // 토론 존재 여부 확인
+    const discussion = await getDiscussionDetail(discussionId);
+    if (!discussion) {
+    throw HttpError(404, "해당 토론을 찾을 수 없습니다.");
+    }
+
+  // 이미 좋아요를 눌렀는지 확인
+    const alreadyLiked = await findDiscussionLike(userId, discussionId);
+    if (alreadyLiked) {
+    throw HttpError(400, "이미 좋아요를 누른 토론입니다.");
+    }
+
+  // 좋아요 등록 &count 증가
+    await addDiscussionLike(userId, discussionId);
+    await increaseDiscussionLikeCount(discussionId);
+
+    return { message: "토론 좋아요가 등록되었습니다." };
 };


### PR DESCRIPTION
**작업내용**
- 토론 상세 페이지에서 사용자가 특정 토론에 좋아요를 등록할 수 있는 기능을 구현
- POST  api/v1/discussions/{discussionId}/like

**테스트**
<좋아요 정상등록>
<img width="1224" height="798" alt="스크린샷 2025-12-10 200802" src="https://github.com/user-attachments/assets/1e885b56-cdc1-4264-8bad-f377b2396570" />

<이미좋아요누른 목록에 또 좋아요를 누른경우>
<img width="1234" height="768" alt="스크린샷 2025-12-10 200813" src="https://github.com/user-attachments/assets/c8e7f5c0-e3ba-458c-b0f3-8e9ad1b92575" />

<존재하지 않는 토론 id에 요청한경우>
<img width="1235" height="784" alt="스크린샷 2025-12-10 200829" src="https://github.com/user-attachments/assets/93c92e54-5738-4d60-bffd-970bb7d92b83" />

<img width="1876" height="109" alt="스크린샷 2025-12-10 201256" src="https://github.com/user-attachments/assets/451aca12-1737-44b7-8776-19f4d626b7ff" />

close #96 