### PR TITLE
[FEAT] 토론 좋아요 취소 API구현 

### DIFF
--- a/src/controllers/discussions_M.controller.ts
+++ b/src/controllers/discussions_M.controller.ts
@@ -25,7 +25,7 @@ import {
     discussionLikeResponseSchema,
 } from "../schemas/discussions_M.schema.js";
 
-import { likeDiscussionService } from "../services/discussions_M.service.js";
+import { likeDiscussionService,unlikeDiscussionService } from "../services/discussions_M.service.js";
 
 
 // 인증된 API 팩토리
@@ -100,6 +100,21 @@ export const handleLikeDiscussion = authEndpointsFactory.build({
     const discussionId = input.discussionId;
 
     const result = await likeDiscussionService(userId, discussionId);
+    return result;
+    },
+});
+
+// 토론 좋아요 취소
+export const handleUnlikeDiscussion = authEndpointsFactory.build({
+    method: "delete",
+    input: discussionLikeInputSchema,
+    output: discussionLikeResponseSchema,
+
+    handler: async ({ input, options }) => {
+    const userId = options.user.user_id;
+    const discussionId = input.discussionId;
+
+    const result = await unlikeDiscussionService(userId, discussionId);
     return result;
     },
 });

--- a/src/repositories/discussions_M.repository.ts
+++ b/src/repositories/discussions_M.repository.ts
@@ -232,3 +232,29 @@ export const increaseDiscussionLikeCount = async (discussionId: number) => {
     [discussionId]
   );
 };
+
+// 좋아요 취소
+export const removeDiscussionLike = async (
+  userId: number,
+  discussionId: number
+) => {
+  await pool.query(
+    `
+    DELETE FROM discussion_like
+    WHERE user_id = ? AND discussion_id = ?
+    `,
+    [userId, discussionId]
+  );
+};
+
+// 좋아요 갯수 1 감소
+export const decreaseDiscussionLikeCount = async (discussionId: number) => {
+  await pool.query(
+    `
+    UPDATE discussion
+    SET like_count = like_count - 1
+    WHERE discussion_id = ? AND like_count > 0
+    `,
+    [discussionId]
+  );
+};

--- a/src/routes/routes.index.ts
+++ b/src/routes/routes.index.ts
@@ -57,6 +57,7 @@ import {
   handleGetDiscussionDetail,
   handleGetDiscussionMessages,
   handleLikeDiscussion,
+  handleUnlikeDiscussion,
 } from "../controllers/discussions_M.controller.js";
 
 export const routing: Routing = {
@@ -73,6 +74,7 @@ export const routing: Routing = {
         "get :discussionId": handleGetDiscussionDetail,
         "get :discussionId/messages": handleGetDiscussionMessages,
         "post :discussionId/like": handleLikeDiscussion, 
+        "delete :discussionId/like": handleUnlikeDiscussion, 
       },
       books: {
         search: handleSearchBooks,

--- a/src/services/discussions_M.service.ts
+++ b/src/services/discussions_M.service.ts
@@ -8,6 +8,8 @@ import {
     findDiscussionLike,
     addDiscussionLike,
     increaseDiscussionLikeCount,
+    removeDiscussionLike,
+    decreaseDiscussionLikeCount
 } from "../repositories/discussions_M.repository.js";
 
 
@@ -113,4 +115,28 @@ export const likeDiscussionService = async (
     await increaseDiscussionLikeCount(discussionId);
 
     return { message: "토론 좋아요가 등록되었습니다." };
+};
+
+// 토론 좋아요 취소
+export const unlikeDiscussionService = async (
+    userId: number,
+    discussionId: number
+) => {
+  // 토론 존재 여부 확인
+    const discussion = await getDiscussionDetail(discussionId);
+    if (!discussion) {
+    throw HttpError(404, "해당 토론을 찾을 수 없습니다.");
+    }
+
+  // 좋아요 여부 확인
+    const liked = await findDiscussionLike(userId, discussionId);
+    if (!liked) {
+    throw HttpError(400, "좋아요를 누르지 않은 토론입니다.");
+    }
+
+  // 좋아요 삭제 & count 감소
+    await removeDiscussionLike(userId, discussionId);
+    await decreaseDiscussionLikeCount(discussionId);
+
+    return { message: "토론 좋아요가 취소되었습니다." };
 };


### PR DESCRIPTION
**-작업내용**
-유저가 누른 토론좋아요목록 취소 구현
-DELETE api/v1/discussions/{discussionId}/like

**테스트**
<좋아요 정상취소>
<img width="1212" height="789" alt="스크린샷 2025-12-10 205734" src="https://github.com/user-attachments/assets/71f7ace7-5a83-4f68-a1ef-d3154614c2aa" />

<좋아요를 누르지 않은경우>
<img width="1274" height="760" alt="스크린샷 2025-12-10 205817" src="https://github.com/user-attachments/assets/9af3a840-2db0-44f9-a633-bb700833b368" />

<존재하지 않는 토론id에 요청한경우>
<img width="1246" height="765" alt="스크린샷 2025-12-10 205830" src="https://github.com/user-attachments/assets/a71c2e22-2eef-4cc2-8bb4-05e69800909d" />

DB확인
<img width="1872" height="108" alt="스크린샷 2025-12-10 205807" src="https://github.com/user-attachments/assets/bc0954dd-bda4-4e35-a553-1d832a35757e" />

close #98