### PR TITLE
[FEAT] 토론 좋아요 여부 조회 API 구현

### DIFF
--- a/src/controllers/discussions_M.controller.ts
+++ b/src/controllers/discussions_M.controller.ts
@@ -11,6 +11,7 @@ import {
     getDiscussionDetailResponseSchema,
     getDiscussionMessagesInputSchema,
     getDiscussionMessagesResponseSchema,
+    discussionLikeStatusSchema ,
 } from "../schemas/discussions_M.schema.js";
 
 import {
@@ -18,14 +19,15 @@ import {
     getDiscussionsByBookService,
     getDiscussionDetailService,
     getDiscussionMessagesService,
+    likeDiscussionService,
+    unlikeDiscussionService ,
+    getDiscussionLikeStatusService,
 } from "../services/discussions_M.service.js";
 
 import {
     discussionLikeInputSchema,
     discussionLikeResponseSchema,
 } from "../schemas/discussions_M.schema.js";
-
-import { likeDiscussionService,unlikeDiscussionService } from "../services/discussions_M.service.js";
 
 
 // 인증된 API 팩토리
@@ -116,5 +118,19 @@ export const handleUnlikeDiscussion = authEndpointsFactory.build({
 
     const result = await unlikeDiscussionService(userId, discussionId);
     return result;
+    },
+});
+
+// 토론 좋아요 여부 조회
+export const handleGetDiscussionLikeStatus = authEndpointsFactory.build({
+    method: "get",
+    input: z.object({
+    discussionId: z.coerce.number().int().positive(),
+    }),
+    output: discussionLikeStatusSchema,
+
+    handler: async ({ input, options }) => {
+    const userId = options.user.user_id;
+    return await getDiscussionLikeStatusService(input.discussionId, userId);
     },
 });

--- a/src/repositories/discussions_M.repository.ts
+++ b/src/repositories/discussions_M.repository.ts
@@ -260,3 +260,21 @@ export const decreaseDiscussionLikeCount = async (discussionId: number) => {
     [discussionId]
   );
 };
+
+// 토론 좋아요 여부 조회
+export const existsDiscussionLike = async (
+  userId: number,
+  discussionId: number
+): Promise<boolean> => {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `
+    SELECT 1 AS found
+    FROM discussion_like
+    WHERE user_id = ? AND discussion_id = ?
+    LIMIT 1
+    `,
+    [userId, discussionId]
+  );
+
+  return rows.length > 0;
+};

--- a/src/routes/routes.index.ts
+++ b/src/routes/routes.index.ts
@@ -59,6 +59,7 @@ import {
   handleGetDiscussionMessages,
   handleLikeDiscussion,
   handleUnlikeDiscussion,
+  handleGetDiscussionLikeStatus
 } from "../controllers/discussions_M.controller.js";
 
 import { handleCreateDiscussionMessage } from "../controllers/discussions.controller.js";
@@ -80,6 +81,8 @@ export const routing: Routing = {
         "post :discussionId/messages": handleCreateDiscussionMessage,
         "post :discussionId/like": handleLikeDiscussion, 
         "delete :discussionId/like": handleUnlikeDiscussion, 
+        "get :discussionId/like-status":
+        handleGetDiscussionLikeStatus,
       },
       
       books: {

--- a/src/schemas/discussions_M.schema.ts
+++ b/src/schemas/discussions_M.schema.ts
@@ -122,3 +122,8 @@ export const discussionLikeInputSchema = z.object({
 export const discussionLikeResponseSchema = z.object({
   message: z.string(),
 });
+
+// 토론 좋아요 여부 조회 Response 스키마
+export const discussionLikeStatusSchema = z.object({
+  isLiked: z.boolean(),
+});

--- a/src/services/discussions_M.service.ts
+++ b/src/services/discussions_M.service.ts
@@ -9,7 +9,8 @@ import {
     addDiscussionLike,
     increaseDiscussionLikeCount,
     removeDiscussionLike,
-    decreaseDiscussionLikeCount
+    decreaseDiscussionLikeCount,
+    existsDiscussionLike,
 } from "../repositories/discussions_M.repository.js";
 
 
@@ -139,4 +140,21 @@ export const unlikeDiscussionService = async (
     await decreaseDiscussionLikeCount(discussionId);
 
     return { message: "토론 좋아요가 취소되었습니다." };
+};
+
+// 토론 좋아요 여부 조회
+export const getDiscussionLikeStatusService = async (
+  discussionId: number,
+  userId: number
+) => {
+  // 토론 존재 여부 확인
+  const discussion = await getDiscussionDetail(discussionId);
+  if (!discussion) {
+    throw HttpError(404, "해당 토론을 찾을 수 없습니다.");
+  }
+
+  // 좋아요 여부 확인
+  const isLiked = await existsDiscussionLike(userId, discussionId);
+
+  return { isLiked };
 };


### PR DESCRIPTION
**작업내용**
-특정 토론의 좋아요 여부 반환

**테스트**
<좋아요 했을경우>
<img width="1225" height="810" alt="스크린샷 2025-12-11 014903" src="https://github.com/user-attachments/assets/5e8c4739-5523-4c3d-b032-dc24745a4469" />

<좋아요 하지 않은경우>
<img width="1275" height="820" alt="스크린샷 2025-12-11 015003" src="https://github.com/user-attachments/assets/a7d3b806-806c-4e08-a2f9-6e4c761519ad" />

<존재하지 않는 id에 요청했을 경우>
<img width="1281" height="828" alt="스크린샷 2025-12-11 015018" src="https://github.com/user-attachments/assets/c24354c0-3cef-4065-a148-50002f0c898a" />

close #106 