### PR TITLE
[FEAT] 인기 토론 조회

### DIFF
--- a/src/controllers/discussions.controller.ts
+++ b/src/controllers/discussions.controller.ts
@@ -1,14 +1,17 @@
+import { z } from "zod";
 import { defaultEndpointsFactory } from "express-zod-api";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import {
     createDiscussionMessageInputSchema,
     createDiscussionMessageResponseSchema,
+    popularDiscussionResponseSchema,
     voteInputSchema,
     voteResponseSchema,
 } from "../schemas/discussions.schema.js";
 import {
     createDiscussionMessageService,
     voteDiscussionService,
+    getPopularDiscussionsService,
 } from "../services/discussions.service.js";
 
 // 인증된 API 팩토리
@@ -23,12 +26,7 @@ export const handleCreateDiscussionMessage = authEndpointsFactory.build({
     handler: async ({ input, options }) => {
         const userId = options.user.user_id;
 
-        return await createDiscussionMessageService(
-            input.discussionId,
-            userId,
-            input.content,
-            input.choice
-        );
+        return await createDiscussionMessageService(input.discussionId, userId, input.content, input.choice);
     },
 });
 
@@ -41,10 +39,16 @@ export const handleVoteDiscussion = authEndpointsFactory.build({
     handler: async ({ input, options }) => {
         const userId = options.user.user_id;
 
-        return await voteDiscussionService(
-            userId,
-            input.discussionId,
-            input.choice
-        );
+        return await voteDiscussionService(userId, input.discussionId, input.choice);
+    },
+});
+
+// GET /api/v1/discussions - 인기 토론 조회
+export const handleGetPopularDiscussions = authEndpointsFactory.build({
+    method: "get",
+    input: z.object({}),
+    output: popularDiscussionResponseSchema,
+    handler: async () => {
+        return await getPopularDiscussionsService();
     },
 });

--- a/src/repositories/discussions.repository.ts
+++ b/src/repositories/discussions.repository.ts
@@ -1,5 +1,5 @@
 import { pool } from "../config/db.config.js";
-import { MyDiscussionRow } from "../schemas/discussions.schema.js";
+import { MyDiscussionRow, PopularDiscussionRow } from "../schemas/discussions.schema.js";
 import { ResultSetHeader, RowDataPacket } from "mysql2/promise";
 
 // 토론 리스트 조회 헬퍼 함수 (내가 작성한 / 좋아요한 공통)
@@ -143,4 +143,30 @@ export const insertVote = async (userId: number, discussionId: number, choice: n
     );
 
     return result.insertId;
+};
+
+// 코멘트 기준 인기 토론 조회
+export const findDiscussionsByCommentCount = async (): Promise<PopularDiscussionRow[]> => {
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT
+            d.discussion_id,
+            d.title,
+            d.content,
+            d.created_at,
+            d.like_count,
+            u.nickname,
+            b.title AS book_title,
+            b.book_id,
+            COUNT(dc.discussion_id) AS comment_count
+        FROM discussion d
+        INNER JOIN user u ON d.user_id = u.user_id
+        INNER JOIN book b ON d.book_id = b.book_id
+        LEFT JOIN discussion_comment dc ON d.discussion_id = dc.discussion_id
+        GROUP BY d.discussion_id, d.title, d.content, d.created_at, d.like_count,
+            u.nickname, b.title, b.book_id
+        ORDER BY comment_count DESC, d.created_at DESC
+        LIMIT 5;`
+    );
+
+    return rows as PopularDiscussionRow[];
 };

--- a/src/routes/routes.index.ts
+++ b/src/routes/routes.index.ts
@@ -63,7 +63,11 @@ import {
     handleGetDiscussionLikeStatus,
 } from "../controllers/discussions_M.controller.js";
 
-import { handleCreateDiscussionMessage, handleVoteDiscussion } from "../controllers/discussions.controller.js";
+import {
+    handleCreateDiscussionMessage,
+    handleVoteDiscussion,
+    handleGetPopularDiscussions,
+} from "../controllers/discussions.controller.js";
 
 export const routing: Routing = {
     api: {
@@ -85,6 +89,7 @@ export const routing: Routing = {
                 "delete :discussionId/like": handleUnlikeDiscussion,
                 "post :discussionId/vote": handleVoteDiscussion,
                 "get :discussionId/like-status": handleGetDiscussionLikeStatus,
+                "": handleGetPopularDiscussions,
             },
 
             books: {

--- a/src/schemas/discussions.schema.ts
+++ b/src/schemas/discussions.schema.ts
@@ -52,6 +52,11 @@ export const voteResponseSchema = z.object({
     message: z.string(),
 });
 
+// 인기 토론 Response 스키마
+export const popularDiscussionResponseSchema = z.object({
+    discussions: z.array(myDiscussionSchema),
+});
+
 // TypeScript 타입 추출
 export type MyDiscussion = z.infer<typeof myDiscussionSchema>;
 export type MyDiscussionsResponse = z.infer<typeof myDiscussionsResponseSchema>;
@@ -59,6 +64,7 @@ export type CreateDiscussionMessageInput = z.infer<typeof createDiscussionMessag
 export type CreateDiscussionMessageResponse = z.infer<typeof createDiscussionMessageResponseSchema>;
 export type VoteInput = z.infer<typeof voteInputSchema>;
 export type VoteResponse = z.infer<typeof voteResponseSchema>;
+export type PopularDiscussionResponse = z.infer<typeof popularDiscussionResponseSchema>;
 
 // MySQL Row 타입
 export interface MyDiscussionRow extends RowDataPacket {
@@ -83,4 +89,16 @@ export interface DiscussionCommentRow extends RowDataPacket {
     choice: number | null;
     created_at: Date;
     updated_at: Date | null;
+}
+
+export interface PopularDiscussionRow extends RowDataPacket {
+    discussion_id: number;
+    title: string;
+    content: string | null;
+    like_count: number;
+    comment_count: number;
+    created_at: Date;
+    book_id: number;
+    book_title: string;
+    nickname: string | null;
 }

--- a/src/services/discussions.service.ts
+++ b/src/services/discussions.service.ts
@@ -5,8 +5,13 @@ import {
     hasUserCommentedOnDiscussion,
     findVoteByUserAndDiscussion,
     insertVote,
+    findDiscussionsByCommentCount,
 } from "../repositories/discussions.repository.js";
-import { CreateDiscussionMessageResponse, VoteResponse } from "../schemas/discussions.schema.js";
+import {
+    CreateDiscussionMessageResponse,
+    VoteResponse,
+    PopularDiscussionResponse,
+} from "../schemas/discussions.schema.js";
 import { addExpToUser } from "../services/mypage.service.js";
 
 const EXP_REWARD = 10;
@@ -103,4 +108,28 @@ export const voteDiscussionService = async (
         console.error(err);
         throw HttpError(500, "투표에 실패했습니다.");
     }
+};
+
+// 인기 토론 조회 서비스
+export const getPopularDiscussionsService = async (): Promise<PopularDiscussionResponse> => {
+    const rawData = await findDiscussionsByCommentCount();
+
+    const popularDiscussions = rawData.map((data) => {
+        return {
+            discussion_id: data.discussion_id,
+            title: data.title,
+            content: data.content,
+            like_count: data.like_count,
+            comment_count: data.comment_count,
+            created_at: data.created_at.toISOString(),
+            book: {
+                book_id: data.book_id,
+                title: data.book_title,
+            },
+            user: {
+                nickname: data.nickname,
+            },
+        };
+    });
+    return { discussions: popularDiscussions };
 };


### PR DESCRIPTION
## 작업 내용
- 인기 토론 조회 API 구현
- 코멘트 개수 순서대로 5개의 토론을 반환
- 코멘트가 1개 이상인 토론이 5개 이하일 때는 코멘트가 0개인 책들도 불러온다.
- 다만 토론 자체가 5개 이하일 경우에는 존재하는 토론만 반환
- 추후 discussion 테이블에 end_date가 추가되면 현재 진행 중인 토론만 반환하도록 수정 예정

## 테스트
- comment_count가 큰 순서대로 토론 정보가 반환되는 것을 볼 수 있다.
<img width="1289" height="429" alt="스크린샷 2025-12-12 001159" src="https://github.com/user-attachments/assets/fbacd3ea-0bc9-4537-8b83-8f69ef045fea" />
<img width="1118" height="543" alt="스크린샷 2025-12-12 001209" src="https://github.com/user-attachments/assets/12e1ecf9-ea40-4906-98d8-89559368cc82" />
