### PR TITLE
[FIX] gemini key NOT FOUND 에러

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -57,6 +57,7 @@ jobs:
                       --env-file /opt/app/.env \
                       -p 3000:3000 \
                       --network checkmate-net \
+                      -v /opt/app/gemini-service-key.json:/app/gemini-service-key.json:ro \
                       ${{ secrets.DOCKER_USERNAME }}/checkmate-server
                       
                     sudo docker image prune -af


### PR DESCRIPTION
## 작업 내용
- 컨테이너에 gemini-key 파일이 없어서 생기는 에러
- EC2의 키 파일 경로를 컨테이너에 볼륨 마운트