### PR TITLE
[REFACTOR] 인기 토론 조회 시 end_date 반영

### DIFF
--- a/src/repositories/discussions.repository.ts
+++ b/src/repositories/discussions.repository.ts
@@ -146,9 +146,7 @@ export const insertVote = async (userId: number, discussionId: number, choice: n
 };
 
 // VS 토론 상세 정보 조회 (종료 여부, 의견 비율 포함)
-export const getVsDiscussionWithStats = async (
-    discussionId: number
-): Promise<VsDiscussionDetailRow | null> => {
+export const getVsDiscussionWithStats = async (discussionId: number): Promise<VsDiscussionDetailRow | null> => {
     const [rows] = await pool.query<RowDataPacket[]>(
         `
         SELECT 
@@ -181,9 +179,7 @@ export interface DiscussionMessageForSummary extends RowDataPacket {
     created_at: Date;
 }
 
-export const getDiscussionMessagesForSummary = async (
-    discussionId: number
-): Promise<DiscussionMessageForSummary[]> => {
+export const getDiscussionMessagesForSummary = async (discussionId: number): Promise<DiscussionMessageForSummary[]> => {
     const [rows] = await pool.query<RowDataPacket[]>(
         `
         SELECT 
@@ -204,9 +200,7 @@ export const getDiscussionMessagesForSummary = async (
 };
 
 // 토론 종료 여부 확인 (end_date가 현재 시간보다 이전인지)
-export const isDiscussionEnded = async (
-    discussionId: number
-): Promise<boolean> => {
+export const isDiscussionEnded = async (discussionId: number): Promise<boolean> => {
     const [rows] = await pool.query<RowDataPacket[]>(
         `
         SELECT 
@@ -240,6 +234,7 @@ export const findDiscussionsByCommentCount = async (): Promise<PopularDiscussion
         INNER JOIN user u ON d.user_id = u.user_id
         INNER JOIN book b ON d.book_id = b.book_id
         LEFT JOIN discussion_comment dc ON d.discussion_id = dc.discussion_id
+        WHERE d.end_date IS NULL
         GROUP BY d.discussion_id, d.title, d.content, d.created_at, d.like_count,
             u.nickname, b.title, b.book_id
         ORDER BY comment_count DESC, d.created_at DESC


### PR DESCRIPTION
## 작업 내용
- 인기 토론 조회 시 현재 진행 중인 토론만 반환하게끔 수정

## 테스트
- discussion_id=2인 토론에 end_date를 지정하면 인기 토론 조회 시 제외됨
<img width="612" height="178" alt="스크린샷 2025-12-13 003935" src="https://github.com/user-attachments/assets/f8a4ea56-45e1-4df7-bb88-730ef6ac7f26" />
<img width="1173" height="779" alt="스크린샷 2025-12-13 004044" src="https://github.com/user-attachments/assets/1450a17a-3f22-4cae-b460-31948a3f384d" />

- end_date=null일 경우 조회가 되는 모습을 볼 수 있다.
<img width="411" height="130" alt="스크린샷 2025-12-13 004108" src="https://github.com/user-attachments/assets/38db1107-d152-43fb-b194-2a0aae79e50a" />
<img width="1376" height="835" alt="스크린샷 2025-12-13 004122" src="https://github.com/user-attachments/assets/e2dd22e2-95de-4941-9dbf-6e3cdef63f8a" />
