### PR TITLE
[FIX] 함께 읽기 기본 정보에 남은 기간 추가

### DIFF
--- a/src/schemas/reading_groups.schema.ts
+++ b/src/schemas/reading_groups.schema.ts
@@ -57,6 +57,7 @@ export const readingGroupOverviewResponseSchema = z.object({
 
     member_count: z.number().int(),
     days_left: z.number().int(),
+    total_days: z.number().int(),
     total_pages: z.number().int().nullable(),
 
     my_progress: z

--- a/src/services/reading_groups.service.ts
+++ b/src/services/reading_groups.service.ts
@@ -25,7 +25,7 @@ import {
     getMembersWithLevelByGroupId,
 } from "../repositories/reading_groups.repository.js";
 
-import { formatDate, calcDaysLeft } from "../utils/date.util.js";
+import { formatDate, calcDaysLeft, calcTotalDays } from "../utils/date.util.js";
 
 
 const DEFAULT_BOOK = {
@@ -201,7 +201,10 @@ export const getReadingGroupOverview = async (
     // 3) days_left 계산 (list에서 쓰는 헬퍼 재사용)
     const daysLeft = calcDaysLeft(group.end_date);
 
-    // 4) 내 진행 정보 구성 (참여 안 했으면 null)
+    // 4) total_days 계산 (시작일과 종료일 사이의 총 일수)
+    const totalDays = calcTotalDays(group.start_date, group.end_date);
+
+    // 5) 내 진행 정보 구성 (참여 안 했으면 null)
     const myProgress = member
         ? {
             current_page: member.current_page,
@@ -215,6 +218,7 @@ export const getReadingGroupOverview = async (
 
         member_count: group.member_count, 
         days_left: daysLeft,
+        total_days: totalDays,
         total_pages: group.page_count,
 
         my_progress: myProgress,

--- a/src/utils/date.util.ts
+++ b/src/utils/date.util.ts
@@ -19,3 +19,15 @@ export const calcDaysLeft = (endDate: string | Date): number => {
 
     return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
 };
+
+// 시작일과 종료일 사이의 총 일수 계산
+export const calcTotalDays = (startDate: string | Date, endDate: string | Date): number => {
+    const start = startDate instanceof Date ? startDate : new Date(startDate);
+    const end = endDate instanceof Date ? endDate : new Date(endDate);
+
+    const diffMs = end.getTime() - start.getTime();
+    const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+    // 시작일과 종료일 모두 포함하므로 +1
+    return diffDays + 1;
+};


### PR DESCRIPTION
## 작업 내용
함께 읽기 기본 정보에 함께 읽기 기간이 얼마나 남아있는 지를 계산해서 조회하여 표시

## 테스트
<img width="1083" height="1008" alt="image" src="https://github.com/user-attachments/assets/f9fab869-345a-4185-87eb-3685cf55b007" />

days_left를 응답에 추가하여 남은 기간을 표시하였다
