### PR TITLE
[FIX] 토론 요약 조회 API에서 is_ended 제거

### DIFF
--- a/src/schemas/discussions.schema.ts
+++ b/src/schemas/discussions.schema.ts
@@ -72,7 +72,6 @@ export const vsDiscussionSummaryResponseSchema = z.object({
     discussion_type: z.literal("VS"),
     option1: z.string(),
     option2: z.string(),
-    is_ended: z.boolean(),
     ended_at: z.string().nullable(),
     total_comments: z.number().int(),
     summary: z.string(),

--- a/src/services/discussions_summary.service.ts
+++ b/src/services/discussions_summary.service.ts
@@ -81,13 +81,6 @@ export const getVsDiscussionSummaryService = async (
         throw HttpError(400, "VS 토론만 요약 조회가 가능합니다.");
     }
 
-    // 종료 여부 확인
-    const isEnded = await isDiscussionEnded(discussionId);
-
-    if (!isEnded) {
-        throw HttpError(400, "토론이 아직 종료되지 않았습니다.");
-    }
-
     // 메시지 조회
     const messages = await getDiscussionMessagesForSummary(discussionId);
 
@@ -135,7 +128,6 @@ export const getVsDiscussionSummaryService = async (
         discussion_type: "VS",
         option1: discussion.option1,
         option2: discussion.option2,
-        is_ended: isEnded,
         ended_at: discussion.end_date ? formatDate(discussion.end_date) : null,
         total_comments: discussion.total_comments,
         summary,


### PR DESCRIPTION
## 작업 내용
- 토론 요약 조회 API에서 응답 값에서 is_ended 제거


## 테스트
<img width="1254" height="1434" alt="image" src="https://github.com/user-attachments/assets/5c488218-147c-4a40-a308-2f5de0028931" />
