### PR TITLE
[FEAT] 인용구 상세 조회 API수정

### DIFF
--- a/src/controllers/quotes.controller.ts
+++ b/src/controllers/quotes.controller.ts
@@ -39,7 +39,7 @@ export const handleGetQuote = authEndpointsFactory.build({
   input: z.object({
     quoteId: z.coerce.number().int().positive(),
   }),
-  output: quoteSchema,
+  output: quoteWithBookSchema,
 
   handler: async ({ input }) => {
     return await getQuoteService(input.quoteId);
@@ -114,9 +114,8 @@ export const handleGetQuotesByBook = authEndpointsFactory.build({
     bookId: z.coerce.number().int().positive(),
   }),
   output: z.object({
-    data: z.array(quoteWithBookSchema),
+    data: z.array(quoteSchema),
   }),
-
   handler: async ({ input }) => {
     const quotes = await getQuotesByBookService(input.bookId);
     return { data: quotes };

--- a/src/services/quotes.service.ts
+++ b/src/services/quotes.service.ts
@@ -2,6 +2,7 @@ import HttpError from "http-errors";
 import {
   createQuote,
   getQuoteById,
+  getQuoteDetailById,
   updateQuote,
   deleteQuote,
   likeQuote,
@@ -48,21 +49,10 @@ export const createQuoteService = async (
 
 // READ 단건
 export const getQuoteService = async (quoteId: number) => {
-  const quote = await getQuoteById(quoteId);
-  if (!quote) throw HttpError(404, "존재하지 않는 인용구입니다.");
+  const row = await getQuoteDetailById(quoteId);
+  if (!row) throw HttpError(404, "존재하지 않는 인용구입니다.");
 
-return {
-    ...quote,
-    created_at: quote.created_at.toISOString(),
-    updated_at: quote.updated_at ? quote.updated_at.toISOString() : null,
-  };
-};
-
-// 도서별 인용구 조회
-export const getQuotesByBookService = async (bookId: number) => {
-  const rows = await getQuotesByBookId(bookId);
-
-  return rows.map((row) => ({
+  return {
     quote_id: row.quote_id,
     user_id: row.user_id,
     nickname: row.nickname,
@@ -80,12 +70,27 @@ export const getQuotesByBookService = async (bookId: number) => {
       description: row.description,
       thumbnail_url: row.thumbnail_url,
       page_count: row.page_count,
-      genres: row.genres
-        ? row.genres.split(",").map((g: string) => g.trim())
-        : [],
+      genres: row.genres ? row.genres.split(",") : [],
     },
+  };
+};
+
+// 도서별 인용구 조회
+export const getQuotesByBookService = async (bookId: number) => {
+  const rows = await getQuotesByBookId(bookId);
+
+  return rows.map((row) => ({
+    quote_id: row.quote_id,
+    user_id: row.user_id,
+    nickname: row.nickname,
+    book_id: row.book_id,
+    content: row.content,
+    like_count: row.like_count,
+    created_at: row.created_at.toISOString(),
+    updated_at: row.updated_at ? row.updated_at.toISOString() : null,
   }));
 };
+
 // UPDATE
 export const updateQuoteService = async (quoteId: number, content: string, userId: number) => {
   const quote = await getQuoteById(quoteId);


### PR DESCRIPTION
**작업내용**
1. 인용구 상세 조회 API 개선
- GET /api/v1/quotes/{quoteId}
- 인용구 상세 조회 시 책 정보(book)를 함께 반환하도록 수정

2. 특정 책 인용구 목록 조회 구조 개선
- GET /api/v1/books/{bookId}/quotes
- 책 정보 반환 제거

**테스트**

<인용구 상세조회>
책 정보도 반환되는걸 볼수 있다.
<img width="2692" height="1447" alt="스크린샷 2025-12-13 143439" src="https://github.com/user-attachments/assets/12dc05c8-8cb0-4598-b1cc-d756c69ab158" />

<특정 책 인용구 목록 조회>
책정보를 반환하지 않는다.
<img width="2667" height="1476" alt="스크린샷 2025-12-13 143813" src="https://github.com/user-attachments/assets/404be448-fe44-4b2c-8ba4-609d7ab27280" />

close #144 