### PR TITLE
[FIX] 함께 읽기 기본정보 (overview)에  thumbnail_url 추가

### DIFF
--- a/src/schemas/reading_groups.schema.ts
+++ b/src/schemas/reading_groups.schema.ts
@@ -54,7 +54,7 @@ export const readingGroupListResponseSchema = z.object({
 export const readingGroupOverviewResponseSchema = z.object({
     reading_group_id: z.number().int(),
     title: z.string(),
-
+    thumbnail_url: z.string().nullable(), 
     member_count: z.number().int(),
     days_left: z.number().int(),
     total_days: z.number().int(),

--- a/src/services/reading_groups.service.ts
+++ b/src/services/reading_groups.service.ts
@@ -215,7 +215,7 @@ export const getReadingGroupOverview = async (
     return {
         reading_group_id: group.reading_group_id,
         title: group.book_title,
-
+        thumbnail_url: group.thumbnail_url,
         member_count: group.member_count, 
         days_left: daysLeft,
         total_days: totalDays,


### PR DESCRIPTION
## 작업 내용
- 함께 읽기 기본정보 (overview) API 응답에  thumbnail_url 추가


## 테스트
<img width="1114" height="1311" alt="image" src="https://github.com/user-attachments/assets/419daaf2-3987-4f77-bc32-ed8fd78d7aa1" />
