### PR TITLE
[FIX] 토론 요약 API 메시지 카운트를 투표카운트로 변경

### DIFF
--- a/src/repositories/discussions.repository.ts
+++ b/src/repositories/discussions.repository.ts
@@ -145,7 +145,7 @@ export const insertVote = async (userId: number, discussionId: number, choice: n
     return result.insertId;
 };
 
-// VS 토론 상세 정보 조회 (종료 여부, 의견 비율 포함)
+// VS 토론 상세 정보 조회 
 export const getVsDiscussionWithStats = async (discussionId: number): Promise<VsDiscussionDetailRow | null> => {
     const [rows] = await pool.query<RowDataPacket[]>(
         `
@@ -159,8 +159,8 @@ export const getVsDiscussionWithStats = async (discussionId: number): Promise<Vs
             d.created_at,
             d.end_date,
             (SELECT COUNT(*) FROM discussion_comment dc WHERE dc.discussion_id = d.discussion_id) AS total_comments,
-            (SELECT COUNT(*) FROM discussion_comment dc WHERE dc.discussion_id = d.discussion_id AND dc.choice = 1) AS option1_count,
-            (SELECT COUNT(*) FROM discussion_comment dc WHERE dc.discussion_id = d.discussion_id AND dc.choice = 2) AS option2_count
+            (SELECT COUNT(*) FROM vote v WHERE v.discussion_id = d.discussion_id AND v.choice = 1) AS option1_count,
+            (SELECT COUNT(*) FROM vote v WHERE v.discussion_id = d.discussion_id AND v.choice = 2) AS option2_count
         FROM discussion d
         WHERE d.discussion_id = ? AND d.discussion_type = 'VS'
         `,


### PR DESCRIPTION
## 작업 내용
- 토론 요약 API에서 discussion_comment 수 를 계산하는 부분을 vote로 변경 



## 테스트
<img width="553" height="211" alt="image" src="https://github.com/user-attachments/assets/5a1a29d7-f271-4f17-a4d8-73618a481c8b" />

<img width="1197" height="1516" alt="image" src="https://github.com/user-attachments/assets/e8d4d6ae-74da-4a25-abe0-2e0790e28596" />

잘 반영되는 것을 확인할 수 있다.