### PR TITLE
[FIX] 인기 토론 조회 에러

### DIFF
--- a/src/repositories/discussions.repository.ts
+++ b/src/repositories/discussions.repository.ts
@@ -145,7 +145,7 @@ export const insertVote = async (userId: number, discussionId: number, choice: n
     return result.insertId;
 };
 
-// VS 토론 상세 정보 조회 
+// VS 토론 상세 정보 조회
 export const getVsDiscussionWithStats = async (discussionId: number): Promise<VsDiscussionDetailRow | null> => {
     const [rows] = await pool.query<RowDataPacket[]>(
         `
@@ -234,7 +234,7 @@ export const findDiscussionsByCommentCount = async (): Promise<PopularDiscussion
         INNER JOIN user u ON d.user_id = u.user_id
         INNER JOIN book b ON d.book_id = b.book_id
         LEFT JOIN discussion_comment dc ON d.discussion_id = dc.discussion_id
-        WHERE d.end_date IS NULL
+        WHERE d.end_date >= NOW()
         GROUP BY d.discussion_id, d.title, d.content, d.created_at, d.like_count,
             u.nickname, b.title, b.book_id
         ORDER BY comment_count DESC, d.created_at DESC
@@ -243,4 +243,3 @@ export const findDiscussionsByCommentCount = async (): Promise<PopularDiscussion
 
     return rows as PopularDiscussionRow[];
 };
-


### PR DESCRIPTION
## 작업 내용
- 기존에는 `end_date IS NULL`인 데이터를 조회했는데, end_date가 자동으로 추가됨에 따라 `end_date >= NOW()`로 코드를 수정
- 종료일시가 현재 시간보다 큰 데이터(종료되지 않은 토론)만 필터링

## 테스트
- 코멘트가 가장 많이 달린 토론은 discussion_id=2
<img width="1496" height="289" alt="스크린샷 2025-12-14 205042" src="https://github.com/user-attachments/assets/bed585b0-401a-4d87-9e30-b195b0621f1c" />
- 하지만 discussion_id=2는 end_date가 지났기 때문에 API 요청 시 조회되지 않는다.
<img width="408" height="280" alt="스크린샷 2025-12-14 205010" src="https://github.com/user-attachments/assets/25d670e3-13b3-400d-a25f-022b8840088f" />
<img width="959" height="792" alt="스크린샷 2025-12-14 205020" src="https://github.com/user-attachments/assets/bfbdd477-da23-4cf9-ac17-b14546c79038" />
