### PR TITLE
[FIX] VS 토론 요약 API 투표 현황 분리

### DIFF
--- a/src/controllers/discussions.controller.ts
+++ b/src/controllers/discussions.controller.ts
@@ -11,12 +11,14 @@ import {
     vsDiscussionSummaryResponseSchema,
     getVoteStatusInputSchema,
     voteStatusResponseSchema,
+    opinionRatioSchema,
 } from "../schemas/discussions.schema.js";
 import {
     createDiscussionMessageService,
     voteDiscussionService,
     getPopularDiscussionsService,
     getVoteStatusService,
+    getVsDiscussionVoteStatsService
 } from "../services/discussions.service.js";
 
 import { getVsDiscussionSummaryService } from "../services/discussions_summary.service.js";
@@ -79,5 +81,17 @@ export const handleGetVoteStatus = authEndpointsFactory.build({
     handler: async ({ input, options }) => {
         const userId = options.user.user_id;
         return await getVoteStatusService(input.discussionId, userId);
+    },
+});
+
+// GET /api/v1/discussions/:discussionId/vote - VS 토론 투표 현황
+export const handleGetVsDiscussionVoteStats = authEndpointsFactory.build({
+    method: "get",
+    input: z.object({
+        discussionId: z.coerce.number().int().positive(),
+    }),
+    output: opinionRatioSchema, 
+    handler: async ({ input }) => {
+        return await getVsDiscussionVoteStatsService(input.discussionId);
     },
 });

--- a/src/repositories/discussions.repository.ts
+++ b/src/repositories/discussions.repository.ts
@@ -159,9 +159,7 @@ export const getVsDiscussionWithStats = async (discussionId: number): Promise<Vs
             d.option2,
             d.created_at,
             d.end_date,
-            (SELECT COUNT(*) FROM discussion_comment dc WHERE dc.discussion_id = d.discussion_id) AS total_comments,
-            (SELECT COUNT(*) FROM vote v WHERE v.discussion_id = d.discussion_id AND v.choice = 1) AS option1_count,
-            (SELECT COUNT(*) FROM vote v WHERE v.discussion_id = d.discussion_id AND v.choice = 2) AS option2_count
+            (SELECT COUNT(*) FROM discussion_comment dc WHERE dc.discussion_id = d.discussion_id) AS total_comments
         FROM discussion d
         WHERE d.discussion_id = ? AND d.discussion_type = 'VS'
         `,

--- a/src/repositories/discussions.repository.ts
+++ b/src/repositories/discussions.repository.ts
@@ -245,20 +245,20 @@ export const findDiscussionsByCommentCount = async (): Promise<PopularDiscussion
     return rows as PopularDiscussionRow[];
 };
 
-
+// VS 토론 투표 통계 조회
 export const getVsVoteStats = async (
     discussionId: number
 ): Promise<VsVoteStatsRow | null> => {
     const [rows] = await pool.query<VsVoteStatsRow[]>(
         `
     SELECT
-      d.discussion_type,
-      d.end_date,
-      COUNT(CASE WHEN dv.choice = 1 THEN 1 END) AS vote1_count,
-      COUNT(CASE WHEN dv.choice = 2 THEN 1 END) AS vote2_count
+        d.discussion_type,
+        d.end_date,
+        COUNT(CASE WHEN dv.choice = 1 THEN 1 END) AS vote1_count,
+        COUNT(CASE WHEN dv.choice = 2 THEN 1 END) AS vote2_count
     FROM discussion d
     LEFT JOIN vote dv
-      ON dv.discussion_id = d.discussion_id
+        ON dv.discussion_id = d.discussion_id
     WHERE d.discussion_id = ?
     GROUP BY d.discussion_id
     `,

--- a/src/routes/routes.index.ts
+++ b/src/routes/routes.index.ts
@@ -71,6 +71,7 @@ import {
     handleGetPopularDiscussions,
     handleGetVsDiscussionSummary,
     handleGetVoteStatus,
+    handleGetVsDiscussionVoteStats
 } from "../controllers/discussions.controller.js";
 
 import { handleInitAiChats, handleAiChats } from "../controllers/ai.controller.js";
@@ -94,6 +95,7 @@ export const routing: Routing = {
                 "post :discussionId/messages": handleCreateDiscussionMessage,
                 "post :discussionId/like": handleLikeDiscussion,
                 "delete :discussionId/like": handleUnlikeDiscussion,
+                "get :discussionId/vote": handleGetVsDiscussionVoteStats,
                 "post :discussionId/vote": handleVoteDiscussion,
                 "get :discussionId/vote-status": handleGetVoteStatus,
                 "get :discussionId/like-status": handleGetDiscussionLikeStatus,

--- a/src/schemas/discussions.schema.ts
+++ b/src/schemas/discussions.schema.ts
@@ -142,8 +142,6 @@ export interface VsDiscussionDetailRow extends RowDataPacket {
     created_at: Date;
     end_date: Date | null;
     total_comments: number;
-    option1_count: number;
-    option2_count: number;
 }
 export interface PopularDiscussionRow extends RowDataPacket {
     discussion_id: number;

--- a/src/schemas/discussions.schema.ts
+++ b/src/schemas/discussions.schema.ts
@@ -59,10 +59,11 @@ export const getVsDiscussionSummaryInputSchema = z.object({
 
 // 의견 비율 스키마
 export const opinionRatioSchema = z.object({
-    option1_count: z.number().int(),
-    option2_count: z.number().int(),
+    vote1_count: z.number().int(),
+    vote2_count: z.number().int(),
     option1_percentage: z.number(),
     option2_percentage: z.number(),
+    end_date: z.string().nullable(),
 });
 
 // VS 토론 요약 응답 스키마
@@ -75,7 +76,6 @@ export const vsDiscussionSummaryResponseSchema = z.object({
     ended_at: z.string().nullable(),
     total_comments: z.number().int(),
     summary: z.string(),
-    opinion_ratio: opinionRatioSchema,
 });
 // 인기 토론 Response 스키마
 export const popularDiscussionResponseSchema = z.object({
@@ -155,4 +155,10 @@ export interface PopularDiscussionRow extends RowDataPacket {
     book_id: number;
     book_title: string;
     nickname: string | null;
+}
+export interface VsVoteStatsRow extends RowDataPacket {
+    end_date: Date | null;
+    vote1_count: number;
+    vote2_count: number;
+    discussion_type: "VS" | "FREE";
 }

--- a/src/services/discussions.service.ts
+++ b/src/services/discussions.service.ts
@@ -161,6 +161,7 @@ export const getVoteStatusService = async (
     };
 };
 
+// VS 토론 투표 통계 조회 서비스
 export const getVsDiscussionVoteStatsService = async (
     discussionId: number
 ): Promise<OpinionRatio> => {

--- a/src/services/discussions.service.ts
+++ b/src/services/discussions.service.ts
@@ -6,14 +6,17 @@ import {
     findVoteByUserAndDiscussion,
     insertVote,
     findDiscussionsByCommentCount,
+    getVsVoteStats
 } from "../repositories/discussions.repository.js";
 import {
     CreateDiscussionMessageResponse,
     VoteResponse,
     PopularDiscussionResponse,
-    VoteStatusResponse
+    VoteStatusResponse,
+    OpinionRatio
 } from "../schemas/discussions.schema.js";
 import { addExpToUser } from "../services/mypage.service.js";
+import { formatDate } from "../utils/date.util.js";
 
 const EXP_REWARD = 10;
 
@@ -155,5 +158,34 @@ export const getVoteStatusService = async (
     return {
         is_voted: !!vote,
         choice: vote ? vote.choice : null,
+    };
+};
+
+export const getVsDiscussionVoteStatsService = async (
+    discussionId: number
+): Promise<OpinionRatio> => {
+    const stats = await getVsVoteStats(discussionId);
+
+    if (!stats) throw HttpError(404, "해당 VS 토론을 찾을 수 없습니다.");
+    if (stats.discussion_type !== "VS") throw HttpError(400, "VS 토론만 투표 현황 조회가 가능합니다.");
+
+    const vote1Count = Number(stats.vote1_count ?? 0);
+    const vote2Count = Number(stats.vote2_count ?? 0);
+    const total = vote1Count + vote2Count;
+
+    const option1Percentage = total > 0
+        ? Math.round((vote1Count / total) * 100)
+        : 0;
+
+    const option2Percentage = total > 0
+        ? Math.round((vote2Count / total) * 100)
+        : 0;
+
+    return {
+        vote1_count: vote1Count,
+        vote2_count: vote2Count,
+        option1_percentage: option1Percentage,
+        option2_percentage: option2Percentage,
+        end_date: stats.end_date ? formatDate(stats.end_date) : null,
     };
 };

--- a/src/services/discussions_summary.service.ts
+++ b/src/services/discussions_summary.service.ts
@@ -84,15 +84,6 @@ export const getVsDiscussionSummaryService = async (
     // 메시지 조회
     const messages = await getDiscussionMessagesForSummary(discussionId);
 
-    // 의견 비율 계산
-    const totalVotes = discussion.option1_count + discussion.option2_count;
-    const option1Percentage = totalVotes > 0
-        ? Math.round((discussion.option1_count / totalVotes) * 100)
-        : 0;
-    const option2Percentage = totalVotes > 0
-        ? Math.round((discussion.option2_count / totalVotes) * 100)
-        : 0;
-
     // AI 요약 생성
     let summary = "작성된 의견이 없어 요약을 생성할 수 없습니다.";
 
@@ -131,11 +122,5 @@ export const getVsDiscussionSummaryService = async (
         ended_at: discussion.end_date ? formatDate(discussion.end_date) : null,
         total_comments: discussion.total_comments,
         summary,
-        opinion_ratio: {
-            option1_count: discussion.option1_count,
-            option2_count: discussion.option2_count,
-            option1_percentage: option1Percentage,
-            option2_percentage: option2Percentage,
-        },
     };
 };


### PR DESCRIPTION
## 작업 내용
- vs토론 요약에서 투표 현황 응답 제거
- 투표 현황 조회 API 구현
- GET api/v1/discussions/{discussionId}/vote

## 테스트 
### 투표 현황 조회
<img width="1226" height="719" alt="image" src="https://github.com/user-attachments/assets/227bf651-5595-4920-8423-6cd8edfbf163" />

### 기존 요약 API 
<img width="1212" height="1165" alt="image" src="https://github.com/user-attachments/assets/6ac9f8e2-b225-44e4-ae18-b2e64fb3308e" />
